### PR TITLE
Add charm details page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ prometheus-flask-exporter==0.2.0
 raven[flask]==6.5.0
 talisker==0.9.8
 theblues==0.3.8
+jujubundlelib==0.5.2
+Markdown==2.6.1
+gfm==0.0.3

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -4,8 +4,8 @@
 
 {% block content %}
 
-<code><pre>
-{{ entity }}
-</pre></code>
+<h1>Bundle details</h1>
+
+{{ entity_data }}
 
 {% endblock %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -279,6 +279,9 @@
   </div>
 </div>
 
-<small>{{ context.charm.ref }}</small>
+<script src="https://jujucharms.com/static/js/build/app/treefilelist.js"></script>
+<script>
+  window.Jujucharms.treeifyFileList();
+</script>
 
 {% endblock %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -1,0 +1,282 @@
+{% extends "_layout.html" %}
+
+{% block title %}{{ context.charm.entity_data['Meta']['charm-metadata']['Name'] }}{% endblock %}
+{% block meta_description %}Deploy {{ context.charm.entity_data['Meta']['charm-metadata']['Name'] }} to bare metal and public or private clouds using the Juju GUI or command line.{% endblock %}
+
+
+{% block meta_tags %}
+  <meta property="og:title" content="{{ context.charm.entity_data['Meta']['charm-metadata']['Name'] }}" />
+  <meta property="og:url" content="{{ request.current_route_url() }}" />
+  {% if description != '' %}
+    <meta property="og:description" content="{{ context.charm.description|striptags }}" />
+  {% endif %}
+  <meta property="og:image" content="{{ request.route_url('icon-proxy-resize', entity_name=name, size=120, file_type='png') }}" />
+{% endblock %}
+
+{% block head_extra %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@ubuntucloud">
+  <meta name="twitter:creator" content="@ubuntucloud">
+  <meta name="twitter:title" content="{{ context.charm.entity_data['Meta']['charm-metadata']['Name'] }} - Juju charm">
+  <meta name="twitter:image" content="{{ request.route_url('icon-proxy-resize', entity_name=name, size=120, file_type='png') }}">
+  <meta name="twitter:description" content="{% if description %}{{ description|striptags }}{% else %}Deploy {{ context.charm.entity_data['Meta']['charm-metadata']['Name'] }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
+  <link rel="canonical" href="{{ canonical_url }}" />
+{% endblock %}
+
+{% block content %}
+
+<small>{{ charm }}</small>
+
+<div class="p-strip--light is-bordered is-shallow" data-js="sticky-header">
+  <header class="row">
+    <div class="col-8">
+      <div class="p-media-object--large u-no-margin--bottom">
+        <img src="{{ context.charm.icon }}" alt="" width="96" id="the-icon" class="p-media-object__image is-round" />
+        <div class="p-media-object__details">
+          <h1 itemprop="name" class="p-media-object__title u-no-margin--bottom u-sv2" style="text-transform:capitalize">
+            <span>
+              {{ context.charm.entity_data['Meta']['charm-metadata']['Name'] }}
+            </span>
+            <sup class="p-heading--three">
+              #{{ context.charm.revision_number }}
+            </sup>
+          </h1>
+          <ul class="p-media-object__meta-list u-no-margin--bottom">
+              <li class="p-media-object__meta-list-item u-no-padding--left">
+                <strong>By</strong> <a href="/u/{{ context.charm.entity_data['Meta']['owner']['User'] }}">{{ context.charm.entity_data['Meta']['owner']['User'] }}</a>
+              </li>
+              <li class="p-media-object__meta-list-item u-no-padding--left">
+                {% if context.charm.revision_number != context.charm.latest_revision['id'] %}
+                  <a href="/{{ context.charm.latest_revision['url'] }}"
+                    onclick="dataLayer.push({
+                      'event' : 'GAEvent',
+                      'eventCategory' : 'Charm Details Link',
+                      'eventAction' : 'Goto latest version',
+                      'eventLabel' : 'Latest version (#ID)',
+                      'eventValue' : '{{ context.charm.latest_revision['full_id'] }}'
+                    });"><strong>Latest version</strong> (#{{ context.charm.latest_revision['id'] }})
+                  </a>
+                {% else %}
+                  <strong>Latest version</strong> (#{{ context.charm.latest_revision['id'] }})
+                {% endif %}
+              </li>
+              <li class="p-media-object__meta-list-item u-no-padding--left">
+                <strong>Series:</strong> {{ context.charm.series|join(', ') }}
+              </li>
+              <li class="p-media-object__meta-list-item u-no-padding--left">
+                <strong>Channels:</strong>
+                {% for channel_details in context.charm.entity_data['Meta']['published']['Info'] %}
+                  {{ channel_details['Channel'] }},
+                {% endfor %}
+              </li>
+            </ul>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="p-code-snippet">
+        <input class="p-code-snippet__input deploy-command__field" value="{{ context.charm.id }}" readonly="readonly">
+        <button class="p-code-snippet__action">Copy to clipboard</button>
+      </div>
+      <p>
+        {% set new_model_url = "/new/?deploy-target=" + context.charm.id %}
+        <a href="{{ new_model_url }}" class="p-button--positive row" rel="nofollow">
+          Add to new model
+        </a>
+      </p>
+      <ul class="p-inline-list u-no-margin--bottom u-equal-height">
+        <li class="p-inline-list__item u-vertically-center">
+          Share:
+        </li>
+        <li class="p-inline-list__item">
+          <a href="https://twitter.com/intent/tweet?text={{ context.charm.display_name }}%20charm&via=ubuntu_cloud&url={{ request.url | urlencode }}">
+            <i class="p-icon--twitter"></i>
+          </a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="https://plus.google.com/share?url={{ request.url|urlencode }}">
+            <i class="p-icon--google"></i>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </header>
+</div>
+
+<div class="p-strip is-shallow">
+  <div class="row">
+    <div class="col-8">
+      {% if context.charm.entity_data['Meta']['charm-metadata']['Description'] != '' %}
+        <h3>Description</h3>
+        <p>{{ context.charm.entity_data['Meta']['charm-metadata']['Description']|safe }}</p>
+      {% endif %}
+      <hr />
+      {% if series and context.charm.series|length > 1 %}
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item"><strong>Series:</strong></li>
+          {% for s in context.charm.series %}
+            <li class="p-inline-list__item"><a href="?series={{ s }}">{{ s }}&nbsp;&rsaquo;</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      {% if context.charm.entity_data['Meta']['charm-metadata']['Tags'] %}
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item"><strong>Tags:</strong></li>
+          {% for tag in context.charm.entity_data['Meta']['charm-metadata']['Tags'] %}
+            <li class="p-inline-list__item"><a href="/q?tags={{ tag }}">{{ tag }}&nbsp;&rsaquo;</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      {% if context.charm.terms %}
+        <h4>Software &amp; terms:</h4>
+        {% for name, term in context.charm.terms.iteritems() %}
+          {% if term.revision %}
+            {% set term_url = '/terms/' + name + '/' + term.revision|string %}
+          {% else %}
+            {% set term_url = '/terms/' + name %}
+          {% endif %}
+          <a target="_blank" href="{{ term_url }}">{{ name }}&nbsp;&rsaquo;</a>
+        {% endfor %}
+      {% endif %}
+      {% if context.charm.readme != '' %}
+        <div id="readme" class="readme">
+          {{ context.charm.readme|safe }}
+        </div>
+      {% endif %}
+
+      <hr />
+
+      {% if context.charm.options %}
+        <div id="configuration">
+          <h3>Configuration</h3>
+          <dl>
+            {% for n,val in context.charm.options.items() %}
+              <dt id="charm-config-{{ n }}">
+                <a href="#charm-config-{{ n }}">
+                  {{ n }}
+                </a>
+              </dt>
+              <dd>
+                {% if val.Type %}
+                  ({{ val.Type }})
+                {% endif %}
+                {% if val.Description %}
+                  {{ val.Description }}
+                {% endif %}
+              </dd>
+              {% if val.Default %}
+                <dd>{{ val.Default }}</dd>
+              {% endif %}
+            {% endfor %}
+          </dl>
+        </div>
+      {% endif %}
+    </div>
+    <aside class="col-4">
+      {% if context.charm.code_url or context.charm.bug_url or context.charm.homepage %}
+        <div class="p-card">
+          <h3>Contribute</h3>
+          <ul class="p-list">
+            {% if context.charm.code_url %}
+              <li class="p-list__item">
+                <a href="{{ context.charm.code_url }}" class="p-link--external">
+                  View repository
+                </a>
+              </li>
+            {% endif %}
+            {% if context.charm.bug_url %}
+              <li class="p-list__item">
+                <a href="{{ context.charm.bug_url }}" class="p-link--external">
+                  Submit a bug
+                </a>
+              </li>
+            {% endif %}
+            {% if context.charm.homepage %}
+              <li class="p-list__item">
+                <a href="{{ context.charm.homepage }}" class="p-link--external">
+                  Project homepage
+                </a>
+              </li>
+            {% endif %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {% if context.charm.resources %}
+        <div class="p-card">
+          <h3>
+            {{ context.charm.resources|length }}
+            resources
+          </h3>
+          <ul class="p-list">
+            {% for resourcename, resourcefile in context.charm.resources.items() %}
+              <li class="p-list__item">
+              {% if resourcefile[1] %}
+                  <a href='{{resourcefile[1]}}' target='_blank'>{{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}</a>
+              {% else %}
+                  {{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}
+              {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {% if context.charm.requires or context.charm.provides %}
+        <div class="p-card" id="relations" style="overflow:visible">
+          <h3>
+            Relations
+            <span class="p-tooltip p-tooltip--top-right">
+              <i class="p-icon--question" aria-describedby="tp-right"></i>
+              <span class="p-tooltip__message" role="tooltip" id="tp-right">Relations enable services to easily and securely share information with each other.</span>
+            </span>
+          </h3>
+          <ul class="p-list">
+            {% if context.charm.requires %}
+              {% for name, value in context.charm.requires.items() %}
+                <li class="p-list__item">
+                  <a target="_blank" href="/q/?provides={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
+                </li>
+              {% endfor %}
+            {% endif %}
+            {% if context.charm.provides %}
+              {% for name, value in context.charm.provides.items() %}
+                <li class="p-list__item">
+                  <a target="_blank" href="/q?requires={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
+                </li>
+              {% endfor %}
+            {% endif %}
+          </ul>
+        </div>
+      {% endif %}
+
+      <div class="p-card" id="files">
+        <h3 class="section__title">
+          Files
+        </h3>
+        <ul class="p-list-tree files__list" aria-multiselectable="true" role="tablist">
+          {% for filename, file_link in context.charm.files.files.items() %}
+            <li class="p-list-tree__item">
+              <a href='{{ file_link }}' target='_blank'>{{ filename }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+        <a target="_blank" class="p-button--neutral archive-url" href="{{ context.charm.archive_url }}">
+            Download .zip
+        </a>
+      </div>
+
+      <div class="p-card" id="juju-card-embed">
+        <h3>Embed this charm</h3>
+        <p>Add this card to your website by copying the code below. <a href="/community/cards">Learn more</a>.</p>
+        <textarea rows="2" cols="70" readonly="readonly" wrap="off" class="col">&lt;script src="https://assets.ubuntu.com/v1/juju-cards-v1.6.0.js"&gt;&lt;/script&gt;
+&lt;div class="juju-card" data-id="{{ id }}" data-dd&gt;&lt;/div&gt;</textarea>
+        <h4>Preview</h4>
+        <script src="https://assets.ubuntu.com/v1/juju-cards-v1.6.0.js"></script>
+        <div class="juju-card" data-id="{{ id }}" data-dd></div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+{% endblock %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -47,7 +47,7 @@
               </li>
               <li class="p-media-object__meta-list-item u-no-padding--left">
                 {% if context.charm.revision_number != context.charm.latest_revision['id'] %}
-                  <a href="/{{ context.charm.latest_revision['url'] }}"
+                  <a href="https://jujucharms.com/{{ context.charm.latest_revision['url'] }}"
                     onclick="dataLayer.push({
                       'event' : 'GAEvent',
                       'eventCategory' : 'Charm Details Link',
@@ -80,7 +80,7 @@
       </div>
       <p>
         {% set new_model_url = "/new/?deploy-target=" + context.charm.id %}
-        <a href="{{ new_model_url }}" class="p-button--positive row" rel="nofollow">
+        <a href="https://jujucharms.com{{ new_model_url }}" class="p-button--positive row" rel="nofollow">
           Add to new model
         </a>
       </p>
@@ -111,7 +111,7 @@
         <p>{{ context.charm.entity_data['Meta']['charm-metadata']['Description']|safe }}</p>
       {% endif %}
       <hr />
-      {% if series and context.charm.series|length > 1 %}
+      {% if context.charm.series and context.charm.series|length > 1 %}
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><strong>Series:</strong></li>
           {% for s in context.charm.series %}
@@ -123,7 +123,7 @@
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><strong>Tags:</strong></li>
           {% for tag in context.charm.entity_data['Meta']['charm-metadata']['Tags'] %}
-            <li class="p-inline-list__item"><a href="/q?tags={{ tag }}">{{ tag }}&nbsp;&rsaquo;</a></li>
+            <li class="p-inline-list__item"><a href="https://jujucharms.com/q?tags={{ tag }}">{{ tag }}&nbsp;&rsaquo;</a></li>
           {% endfor %}
         </ul>
       {% endif %}
@@ -235,14 +235,14 @@
             {% if context.charm.requires %}
               {% for name, value in context.charm.requires.items() %}
                 <li class="p-list__item">
-                  <a target="_blank" href="/q/?provides={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
+                  <a target="_blank" href="https://jujucharms.com/q/?provides={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
                 </li>
               {% endfor %}
             {% endif %}
             {% if context.charm.provides %}
               {% for name, value in context.charm.provides.items() %}
                 <li class="p-list__item">
-                  <a target="_blank" href="/q?requires={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
+                  <a target="_blank" href="https://jujucharms.com/q?requires={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
                 </li>
               {% endfor %}
             {% endif %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -86,7 +86,7 @@
       </p>
       <ul class="p-inline-list u-no-margin--bottom u-equal-height">
         <li class="p-inline-list__item u-vertically-center">
-          Share:
+          <strong>Share:</strong>
         </li>
         <li class="p-inline-list__item">
           <a href="https://twitter.com/intent/tweet?text={{ context.charm.display_name }}%20charm&via=ubuntu_cloud&url={{ request.url | urlencode }}">
@@ -226,7 +226,7 @@
         <div class="p-card" id="relations" style="overflow:visible">
           <h3>
             Relations
-            <span class="p-tooltip p-tooltip--top-right">
+            <span class="p-tooltip p-tooltip--top-right" style="position: relative; top: -2px;">
               <i class="p-icon--question" aria-describedby="tp-right"></i>
               <span class="p-tooltip__message" role="tooltip" id="tp-right">Relations enable services to easily and securely share information with each other.</span>
             </span>
@@ -255,7 +255,7 @@
           Files
         </h3>
         <ul class="p-list-tree files__list" aria-multiselectable="true" role="tablist">
-          {% for filename, file_link in context.charm.files.files.items() %}
+          {% for filename, file_link in context.charm.files.items() %}
             <li class="p-list-tree__item">
               <a href='{{ file_link }}' target='_blank'>{{ filename }}</a>
             </li>
@@ -270,13 +270,15 @@
         <h3>Embed this charm</h3>
         <p>Add this card to your website by copying the code below. <a href="/community/cards">Learn more</a>.</p>
         <textarea rows="2" cols="70" readonly="readonly" wrap="off" class="col">&lt;script src="https://assets.ubuntu.com/v1/juju-cards-v1.6.0.js"&gt;&lt;/script&gt;
-&lt;div class="juju-card" data-id="{{ id }}" data-dd&gt;&lt;/div&gt;</textarea>
+&lt;div class="juju-card" data-id="{{ context.charm.card_id }}" data-dd&gt;&lt;/div&gt;</textarea>
         <h4>Preview</h4>
         <script src="https://assets.ubuntu.com/v1/juju-cards-v1.6.0.js"></script>
-        <div class="juju-card" data-id="{{ id }}" data-dd></div>
+        <div class="juju-card" data-id="{{ context.charm.card_id }}" data-dd></div>
       </div>
     </aside>
   </div>
 </div>
+
+<small>{{ context.charm.ref }}</small>
 
 {% endblock %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -43,7 +43,7 @@
           </h1>
           <ul class="p-media-object__meta-list u-no-margin--bottom">
               <li class="p-media-object__meta-list-item u-no-padding--left">
-                <strong>By</strong> <a href="/u/{{ context.charm.entity_data['Meta']['owner']['User'] }}">{{ context.charm.entity_data['Meta']['owner']['User'] }}</a>
+                <strong>By</strong> <a href="https://jujucharms.com/u/{{ context.charm.entity_data['Meta']['owner']['User'] }}">{{ context.charm.entity_data['Meta']['owner']['User'] }}</a>
               </li>
               <li class="p-media-object__meta-list-item u-no-padding--left">
                 {% if context.charm.revision_number != context.charm.latest_revision['id'] %}
@@ -212,7 +212,7 @@
             {% for resourcename, resourcefile in context.charm.resources.items() %}
               <li class="p-list__item">
               {% if resourcefile[1] %}
-                  <a href='{{resourcefile[1]}}' target='_blank'>{{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}</a>
+                  <a href='https://jujucharms.com{{resourcefile[1]}}' target='_blank'>{{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}</a>
               {% else %}
                   {{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}
               {% endif %}

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -1,15 +1,16 @@
+import os
 
 from flask import abort
 from theblues.charmstore import CharmStore
 from jujubundlelib import references
+from theblues.errors import EntityNotFound
 
-import requests
-import markdown
 import gfm
 import re
 
 
 cs = CharmStore("https://api.jujucharms.com/v5")
+
 
 def get_charm_or_bundle(name):
     try:
@@ -23,23 +24,33 @@ def get_charm_or_bundle(name):
     bzr_url, revisions = _extract_from_extrainfo(meta, ref)
     bugs_url, homepage = _extract_from_commoninfo(meta)
     revision_list = meta['revision-info'].get('Revisions')
+    latest_revision = {
+        'id': int(revision_list[0].split('-')[-1]),
+        'full_id': revision_list[0],
+        'url': '{}/{}'.format(
+            meta['charm-metadata']['Name'],
+            int(revision_list[0].split('-')[-1])
+        )}
 
     charm_or_bundle = {
         'archive_url': cs.archive_url(ref),
         'bugs_url': bugs_url,
         'bzr_url': bzr_url,
         'entity_data': entity_data,
-        'files': _getEntityFiles(ref, meta['manifest']),
+        'files': _get_entity_files(ref, meta['manifest']),
         'homepage': homepage,
-        'icon': _parse_charm_icon(charm_or_bundle_id),
+        'icon': cs.charm_icon_url(charm_or_bundle_id),
         'id': charm_or_bundle_id,
-        'latest_revision': _expand_revision(revision_list[0], meta['charm-metadata']['Name']),
+        'card_id': ref.path(),
+        'latest_revision': latest_revision,
         'options': meta.get('charm-config', {}).get('Options'),
         'owner': entity_data.get('owner', {}).get('User'),
         'provides': meta['charm-metadata'].get('Provides'),
         'requires': meta['charm-metadata'].get('Requires'),
-        'resources': _extract_resources(ref, meta.get('resources')),
-        'readme': _render_markdown(cs.entity_readme_content(charm_or_bundle_id)),
+        'resources': _extract_resources(ref, meta.get('resources', {})),
+        'readme': _render_markdown(
+            cs.entity_readme_content(charm_or_bundle_id)
+        ),
         'revision_list': revision_list,
         'revision_number': ref.revision,
         'revisions': revisions,
@@ -50,71 +61,36 @@ def get_charm_or_bundle(name):
     return charm_or_bundle
 
 
-def _getEntityFiles(ref, manifest=None):
+def _get_entity_files(ref, manifest=None):
     try:
-        files = cs.files(ref, manifest=manifest)
+        files = cs.files(ref, manifest=manifest) or {}
     except EntityNotFound:
         files = {}
-    if not files:
-        files = {}
-    try:
-        readme = cs.entity_readme_content(ref)
-    except EntityNotFound:
-        readme = None
-    return {
-        'files': files,
-        'readme': readme,
-    }
+    return files
 
 
-def _parse_charm_icon(charm_id):
-    try:
-        return cs.charm_icon_url(charm_id)
-    except Exception:
-        return abort(500, "Entity not found {}".format(charm_id))
-
-
-def _expand_revision(revision_id, charm_name):
-    '''From a revision id, create a Dict.
-    @param revision_id A revision id string.
-    @param charm_name The name of the charm
-    '''
-
-    id = revision_id.split('-')[-1]
-    url = charm_name + '/' + id
-    return {
-        'id': int(id),
-        'full_id': revision_id,
-        'url': url}
-
-
-def _extract_resources(ref, data):
+def _extract_resources(ref, resources):
     """Extract data from resources metadata.
     @param ref The reference of the entity.
-    @param data the resources metadata associated with the entity.
+    @param resources the resources metadata associated with the entity.
     @return a dictionary of resource name and an array containing
             the file extension, the file link of the resource.
     """
-    if not data:
-        # if resources are not present return an empty dictionary
-        return {}
+    result = {}
+    for resource in resources:
+        resource_url = ""
+        if resource['Revision'] >= 0:
+            resource_url = cs.resource_url(
+                ref,
+                resource['Name'],
+                resource['Revision']
+            )
+        result[resource['Name']] = [
+            os.path.splitext(resource['Path'])[1],
+            resource_url
+        ]
 
-    try:
-        resources = {}
-        for i in data:
-            resource_url = ""
-            if i['Revision'] >= 0:
-                resource_url = self.cs.resource_url(ref,
-                                                    i['Name'],
-                                                    i['Revision'])
-            resources[i['Name']] = [os.path.splitext(i['Path'])[1],
-                                    resource_url]
-    except (KeyError, TypeError, ValueError):
-        log.info('Unable to read resources for ',
-                    data)
-        return {}
-
-    return resources
+    return result
 
 
 def _get_bug_url(name, bugs_url):
@@ -128,12 +104,14 @@ def _get_bug_url(name, bugs_url):
 
 
 def _render_markdown(content):
+    html = gfm.markdown(content)
+
     try:
-        html = gfm.markdown(content)
-        html = convert_http_to_https(html)
+        html = _convert_http_to_https(html)
     except Exception:
         # Leave the readme unparsed.
         pass
+
     return html
 
 
@@ -158,8 +136,10 @@ def _bzr_to_launchpad_url(link):
 
 def _extract_from_extrainfo(charm_data, ref):
     extra_info = charm_data.get('extra-info', {})
-    revisions = (extra_info.get('bzr-revisions') or
-                    extra_info.get('vcs-revisions'))
+    revisions = (
+        extra_info.get('bzr-revisions') or
+        extra_info.get('vcs-revisions')
+    )
     bzr_url = extra_info.get('bzr-url')
     return bzr_url, revisions
 

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import re
 
@@ -64,6 +65,9 @@ def _parse_charm_or_bundle(entity_data):
 def _get_entity_files(ref, manifest=None):
     try:
         files = cs.files(ref, manifest=manifest) or {}
+        files = collections.OrderedDict(
+            sorted(files.items())
+        )
     except EntityNotFound:
         files = {}
     return files

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -6,29 +6,12 @@ from jujubundlelib import references
 from theblues.charmstore import CharmStore
 from theblues.errors import EntityNotFound
 
-
 cs = CharmStore("https://api.jujucharms.com/v5")
 
 
-def get_charm_or_bundle_with_series_version(name, series, version):
+def get_charm_or_bundle(reference):
     try:
-        entity_data = cs.entity(name, True)
-        return _parse_charm_or_bundle(entity_data)
-    except EntityNotFound:
-        return None
-
-
-def get_charm_or_bundle_with_series(name, series):
-    try:
-        entity_data = cs.entity(name, True)
-        return _parse_charm_or_bundle(entity_data)
-    except EntityNotFound:
-        return None
-
-
-def get_charm_or_bundle(name):
-    try:
-        entity_data = cs.entity(name, True)
+        entity_data = cs.entity(reference, True)
         return _parse_charm_or_bundle(entity_data)
     except EntityNotFound:
         return None

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -127,13 +127,6 @@ def _convert_http_to_https(content):
     return content
 
 
-def _bzr_to_launchpad_url(link):
-    if link is not None:
-        return link.replace('lp:', 'http://code.launchpad.net/')
-    else:
-        return None
-
-
 def _extract_from_extrainfo(charm_data, ref):
     extra_info = charm_data.get('extra-info', {})
     revisions = (

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -15,7 +15,7 @@ cs = CharmStore("https://api.jujucharms.com/v5")
 def get_charm_or_bundle(name):
     try:
         entity_data = cs.entity(name, True)
-    except Exception:
+    except EntityNotFound:
         return abort(404, "Entity not found {}".format(name))
 
     charm_or_bundle_id = entity_data['Id']

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -1,0 +1,172 @@
+
+from flask import abort
+from theblues.charmstore import CharmStore
+from jujubundlelib import references
+
+import requests
+import markdown
+import gfm
+import re
+
+
+cs = CharmStore("https://api.jujucharms.com/v5")
+
+def get_charm_or_bundle(name):
+    try:
+        entity_data = cs.entity(name, True)
+    except Exception:
+        return abort(404, "Entity not found {}".format(name))
+
+    charm_or_bundle_id = entity_data['Id']
+    ref = references.Reference.from_string(charm_or_bundle_id)
+    meta = entity_data.get('Meta', None)
+    bzr_url, revisions = _extract_from_extrainfo(meta, ref)
+    bugs_url, homepage = _extract_from_commoninfo(meta)
+    revision_list = meta['revision-info'].get('Revisions')
+
+    charm_or_bundle = {
+        'archive_url': cs.archive_url(ref),
+        'bugs_url': bugs_url,
+        'bzr_url': bzr_url,
+        'entity_data': entity_data,
+        'files': _getEntityFiles(ref, meta['manifest']),
+        'homepage': homepage,
+        'icon': _parse_charm_icon(charm_or_bundle_id),
+        'id': charm_or_bundle_id,
+        'latest_revision': _expand_revision(revision_list[0], meta['charm-metadata']['Name']),
+        'options': meta.get('charm-config', {}).get('Options'),
+        'owner': entity_data.get('owner', {}).get('User'),
+        'provides': meta['charm-metadata'].get('Provides'),
+        'requires': meta['charm-metadata'].get('Requires'),
+        'resources': _extract_resources(ref, meta.get('resources')),
+        'readme': _render_markdown(cs.entity_readme_content(charm_or_bundle_id)),
+        'revision_list': revision_list,
+        'revision_number': ref.revision,
+        'revisions': revisions,
+        'series': meta.get('supported-series', {}).get('SupportedSeries'),
+        'is_charm': 'charm-metadata' in meta
+    }
+
+    return charm_or_bundle
+
+
+def _getEntityFiles(ref, manifest=None):
+    try:
+        files = cs.files(ref, manifest=manifest)
+    except EntityNotFound:
+        files = {}
+    if not files:
+        files = {}
+    try:
+        readme = cs.entity_readme_content(ref)
+    except EntityNotFound:
+        readme = None
+    return {
+        'files': files,
+        'readme': readme,
+    }
+
+
+def _parse_charm_icon(charm_id):
+    try:
+        return cs.charm_icon_url(charm_id)
+    except Exception:
+        return abort(500, "Entity not found {}".format(charm_id))
+
+
+def _expand_revision(revision_id, charm_name):
+    '''From a revision id, create a Dict.
+    @param revision_id A revision id string.
+    @param charm_name The name of the charm
+    '''
+
+    id = revision_id.split('-')[-1]
+    url = charm_name + '/' + id
+    return {
+        'id': int(id),
+        'full_id': revision_id,
+        'url': url}
+
+
+def _extract_resources(ref, data):
+    """Extract data from resources metadata.
+    @param ref The reference of the entity.
+    @param data the resources metadata associated with the entity.
+    @return a dictionary of resource name and an array containing
+            the file extension, the file link of the resource.
+    """
+    if not data:
+        # if resources are not present return an empty dictionary
+        return {}
+
+    try:
+        resources = {}
+        for i in data:
+            resource_url = ""
+            if i['Revision'] >= 0:
+                resource_url = self.cs.resource_url(ref,
+                                                    i['Name'],
+                                                    i['Revision'])
+            resources[i['Name']] = [os.path.splitext(i['Path'])[1],
+                                    resource_url]
+    except (KeyError, TypeError, ValueError):
+        log.info('Unable to read resources for ',
+                    data)
+        return {}
+
+    return resources
+
+
+def _get_bug_url(name, bugs_url):
+    '''Create a link to the bug tracker on Launchpad.
+    @param name the charm name.
+    @return a URL for the bug tracker.
+    '''
+    if bugs_url:
+        return bugs_url
+    return 'https://bugs.launchpad.net/charms/+source/{}'.format(name)
+
+
+def _render_markdown(content):
+    try:
+        html = gfm.markdown(content)
+        html = convert_http_to_https(html)
+    except Exception:
+        # Leave the readme unparsed.
+        pass
+    return html
+
+
+def _convert_http_to_https(content):
+    '''Convert any non secure inclusion of assets to secure.
+        @param content the content to parse as a string.
+        @return the parsed content with http replaces with https
+    '''
+    insensitive_link = re.compile(re.escape('src="http:'), re.IGNORECASE)
+    content = insensitive_link.sub('src="https:', content)
+    insensitive_link = re.compile(re.escape("src='http:"), re.IGNORECASE)
+    content = insensitive_link.sub("src='https:", content)
+    return content
+
+
+def _bzr_to_launchpad_url(link):
+    if link is not None:
+        return link.replace('lp:', 'http://code.launchpad.net/')
+    else:
+        return None
+
+
+def _extract_from_extrainfo(charm_data, ref):
+    extra_info = charm_data.get('extra-info', {})
+    revisions = (extra_info.get('bzr-revisions') or
+                    extra_info.get('vcs-revisions'))
+    bzr_url = extra_info.get('bzr-url')
+    return bzr_url, revisions
+
+
+def _extract_from_commoninfo(bundle_data):
+    # ...and common info...
+    common_info = bundle_data.get('common-info', {})
+    bugs_url = common_info.get('bugs-url')
+    homepage = common_info.get('homepage')
+    return bugs_url, homepage

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,14 +1,10 @@
-from pprint import pformat
+from flask import Blueprint, render_template
+from webapp.store import models
 
-from flask import Blueprint, abort, render_template
-
-from theblues.charmstore import CharmStore
 
 jaasstore = Blueprint(
   'jaasstore', __name__,
   template_folder='/templates', static_folder='/static')
-
-cs = CharmStore("https://api.jujucharms.com/v5")
 
 
 @jaasstore.route('/store')
@@ -16,12 +12,34 @@ def store():
     return render_template('store/store.html')
 
 
-@jaasstore.route('/<entity_name>')
-def details(entity_name):
-    try:
-        entity = cs.entity(entity_name)
-        entity_formatted = pformat(entity, 1, 120)
-    except Exception:
-        return abort(404, "Entity not found {}".format(entity_name))
+@jaasstore.route('/u/<user_name>/<entity_name>/<series>/<version>')
+def user_details_series_version():
+    raise NotImplementedError()
 
-    return render_template('store/details.html', entity=entity_formatted)
+
+@jaasstore.route('/u/<user_name>/<entity_name>/<series>')
+def user_details_series():
+    raise NotImplementedError()
+
+@jaasstore.route('/u/<user_name>/<entity_name>/')
+def user_details():
+    raise NotImplementedError()
+
+@jaasstore.route('/<charm_or_bundle_name>')
+def details(charm_or_bundle_name):
+    charm_or_bundle = models.get_charm_or_bundle(charm_or_bundle_name)
+
+    if charm_or_bundle['is_charm']:
+        return render_template(
+            'store/charm-details.html',
+            context={'charm': charm_or_bundle}
+        )
+    else:
+        return render_template(
+            'store/bundle-details.html',
+            context={'bundle': charm_or_bundle}
+        )
+
+
+
+

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -21,9 +21,11 @@ def user_details_series_version():
 def user_details_series():
     raise NotImplementedError()
 
+
 @jaasstore.route('/u/<user_name>/<entity_name>/')
 def user_details():
     raise NotImplementedError()
+
 
 @jaasstore.route('/<charm_or_bundle_name>')
 def details(charm_or_bundle_name):
@@ -39,7 +41,3 @@ def details(charm_or_bundle_name):
             'store/bundle-details.html',
             context={'bundle': charm_or_bundle}
         )
-
-
-
-

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,5 +1,7 @@
-from flask import Blueprint, abort, render_template
+from flask import Blueprint, abort, request, render_template
 from webapp.store import models
+
+from jujubundlelib import references
 
 
 jaasstore = Blueprint(
@@ -12,69 +14,17 @@ def store():
     return render_template('store/store.html')
 
 
-@jaasstore.route('/u/<user_name>/<entity_name>/<series>/<version>')
-def user_details_series_version():
-    raise NotImplementedError()
-
-
-@jaasstore.route('/u/<user_name>/<entity_name>/<series>')
-def user_details_series():
-    raise NotImplementedError()
-
-
 @jaasstore.route('/u/<user_name>/<entity_name>/')
 def user_details():
     raise NotImplementedError()
 
 
-@jaasstore.route('/<charm_or_bundle_name>/<series>/<version>')
-def details_with_series_version(charm_or_bundle_name, series, version):
-    charm_or_bundle = models.get_charm_or_bundle_with_series_version(
-        charm_or_bundle_name,
-        series,
-        version,
-    )
-
-    if charm_or_bundle:
-        if charm_or_bundle['is_charm']:
-            return render_template(
-                'store/charm-details.html',
-                context={'charm': charm_or_bundle}
-            )
-        else:
-            return render_template(
-                'store/bundle-details.html',
-                context={'bundle': charm_or_bundle}
-            )
-    else:
-        return abort(404, "Entity not found {}".format(charm_or_bundle_name))
-
-
-@jaasstore.route('/<charm_or_bundle_name>/<series>')
-def details_with_series(charm_or_bundle_name, series):
-    charm_or_bundle = models.get_charm_or_bundle_with_series(
-        charm_or_bundle_name,
-        series
-    )
-
-    if charm_or_bundle:
-        if charm_or_bundle['is_charm']:
-            return render_template(
-                'store/charm-details.html',
-                context={'charm': charm_or_bundle}
-            )
-        else:
-            return render_template(
-                'store/bundle-details.html',
-                context={'bundle': charm_or_bundle}
-            )
-    else:
-        return abort(404, "Entity not found {}".format(charm_or_bundle_name))
-
-
 @jaasstore.route('/<charm_or_bundle_name>')
-def details(charm_or_bundle_name):
-    charm_or_bundle = models.get_charm_or_bundle(charm_or_bundle_name)
+@jaasstore.route('/<charm_or_bundle_name>/<series_or_version>')
+@jaasstore.route('/<charm_or_bundle_name>/<series_or_version>/<version>')
+def details(charm_or_bundle_name, series_or_version=None, version=None):
+    reference = references.Reference.from_jujucharms_url(request.path[1:])
+    charm_or_bundle = models.get_charm_or_bundle(reference)
 
     if charm_or_bundle:
         if charm_or_bundle['is_charm']:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, abort, render_template
 from webapp.store import models
 
 
@@ -27,17 +27,65 @@ def user_details():
     raise NotImplementedError()
 
 
+@jaasstore.route('/<charm_or_bundle_name>/<series>/<version>')
+def details_with_series_version(charm_or_bundle_name, series, version):
+    charm_or_bundle = models.get_charm_or_bundle_with_series_version(
+        charm_or_bundle_name,
+        series,
+        version,
+    )
+
+    if charm_or_bundle:
+        if charm_or_bundle['is_charm']:
+            return render_template(
+                'store/charm-details.html',
+                context={'charm': charm_or_bundle}
+            )
+        else:
+            return render_template(
+                'store/bundle-details.html',
+                context={'bundle': charm_or_bundle}
+            )
+    else:
+        return abort(404, "Entity not found {}".format(charm_or_bundle_name))
+
+
+@jaasstore.route('/<charm_or_bundle_name>/<series>')
+def details_with_series(charm_or_bundle_name, series):
+    charm_or_bundle = models.get_charm_or_bundle_with_series(
+        charm_or_bundle_name,
+        series
+    )
+
+    if charm_or_bundle:
+        if charm_or_bundle['is_charm']:
+            return render_template(
+                'store/charm-details.html',
+                context={'charm': charm_or_bundle}
+            )
+        else:
+            return render_template(
+                'store/bundle-details.html',
+                context={'bundle': charm_or_bundle}
+            )
+    else:
+        return abort(404, "Entity not found {}".format(charm_or_bundle_name))
+
+
 @jaasstore.route('/<charm_or_bundle_name>')
 def details(charm_or_bundle_name):
     charm_or_bundle = models.get_charm_or_bundle(charm_or_bundle_name)
 
-    if charm_or_bundle['is_charm']:
-        return render_template(
-            'store/charm-details.html',
-            context={'charm': charm_or_bundle}
-        )
+    if charm_or_bundle:
+        if charm_or_bundle['is_charm']:
+            return render_template(
+                'store/charm-details.html',
+                context={'charm': charm_or_bundle}
+            )
+        else:
+            return render_template(
+                'store/bundle-details.html',
+                context={'bundle': charm_or_bundle}
+            )
     else:
-        return render_template(
-            'store/bundle-details.html',
-            context={'bundle': charm_or_bundle}
-        )
+        return abort(404, "Entity not found {}".format(charm_or_bundle_name))


### PR DESCRIPTION
## Done
Added the template and data for the charm details page.

## QA
- Go to /wordpress
- See that there is content
- Check that /haproxy/42 loads version 42

## Details
Fixes https://github.com/ubuntudesign/juju-squad/issues/348