### PR TITLE
Health check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ gunicorn[gevent]
 prometheus-flask-exporter==0.2.0
 raven[flask]==6.5.0
 statsd<3.3.0
-talisker==0.9.8
+talisker==0.9.14
 theblues==0.3.8
 jujubundlelib==0.5.2
 Markdown==2.6.1

--- a/webapp/jaasai/views.py
+++ b/webapp/jaasai/views.py
@@ -73,3 +73,10 @@ def community_charmers():
 @jaasai.route('/community/partners')
 def community_partners():
     return render_template('jaasai/community/partners.html')
+
+
+@jaasai.route('/_status/check')
+def health_check():
+    """ Health check end point used by Talisker.
+    """
+    return ('', 200)


### PR DESCRIPTION
This adds a health check endpoint to return to Talisker, as Talisker checks against this URL.

Currently the endpoint is caught by a wildcard URL rule which incorrectly handles this path.

## QA

- `./run`
- Check URL returns 200 OK - http://0.0.0.0:8029/_status/check