### PR TITLE
Preconnect to Assets Server and Google Analytics

### DIFF
--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html class="no-js" lang="en" dir="ltr" itemscope itemtype="http://schema.org/Product">
 <head>
-
+  <link rel="preconnect" href="https://www.google-analytics.com">
+  <link rel="preconnect" href="https://assets.ubuntu.com">
   <title>{% block title %}{% endblock %} | Juju</title>
   <meta charset="UTF-8" />
   <meta name="description" content="{% block description %}{% endblock %}" />
@@ -18,7 +19,6 @@
   <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/static/img/icons/apple-touch-icon-152x152-precomposed.png"/>
   <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/static/img/icons/apple-touch-icon-180x180-precomposed.png"/>
   <link rel="apple-touch-icon-precomposed" href="/static/img/icons/apple-touch-icon-precomposed.png"/>
-
 
   <!-- google fonts -->
   <link href='https://fonts.googleapis.com/css?family=Ubuntu:400,300,300italic,400italic,700,700italic%7CUbuntu+Mono' rel='stylesheet' type='text/css' />

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -3,19 +3,11 @@
 <head>
 
   <title>{% block title %}{% endblock %} | Juju</title>
-
   <meta charset="UTF-8" />
   <meta name="description" content="{% block description %}{% endblock %}" />
-
   <meta name="author" content="Canonical" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-
-  <!--[if IE]>
-  <meta http-equiv="X-UA-Compatible" content="IE=8">
-  <![endif]-->
-
   <link rel="shortcut icon" href="/static/img/favicon.ico" type="image/x-icon" />
-
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/static/img/icons/apple-touch-icon-57x57-precomposed.png"/>
   <link rel="apple-touch-icon-precomposed" sizes="60x60" href="/static/img/icons/apple-touch-icon-60x60-precomposed.png"/>
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/static/img/icons/apple-touch-icon-72x72-precomposed.png"/>


### PR DESCRIPTION
## Done

- Removed redundant IE comment from base template
- Added `preconnect` link to Google Analytics and Assets Server

## QA

- Sanity check code
- Run site with `./run`
- Check that when site loads, the links are in the head