### PR TITLE
Bundle copy-snippet as ES6 module

### DIFF
--- a/static/js/src/app.js
+++ b/static/js/src/app.js
@@ -1,7 +1,9 @@
 // import modules
-import showContactDetails from './modules/show-contact-details';
 import {createNav} from '@canonical/global-nav';
+import showContactDetails from './modules/show-contact-details';
+import copySnippet from './modules/copy-snippet';
 
 // Instantiate modules
-showContactDetails();
 createNav({maxWidth: '64.875rem'});
+showContactDetails();
+copySnippet();

--- a/static/js/src/modules/copy-snippet.js
+++ b/static/js/src/modules/copy-snippet.js
@@ -1,7 +1,7 @@
 /**
   Allows users to click button on code snippet pattern to copy contents to clipboard
 **/
-window.Jujucharms.copyCodeSnippets = () => {
+const copySnippet = () => {
   /**
     Activate copy button on code snippets
     @method copyCodeSnippets.instantiateCopyButtons
@@ -22,8 +22,7 @@ window.Jujucharms.copyCodeSnippets = () => {
   };
 
   /**
-    Copys string to clipboard
-
+    Copies string to clipboard
     @method copyCodeSnippets.copyToClipboard
     @param str {String} String to be copied to clipboard
     @static
@@ -56,3 +55,5 @@ window.Jujucharms.copyCodeSnippets = () => {
     instantiateCopyButtons();
   }
 };
+
+export default copySnippet;


### PR DESCRIPTION
## Done

- Bundle up JS util to add a copy button on entity details page as ES6 module

## QA

- View demo link below
- Navigate to `/nagios/trusty/7`
- Click the copy button next to the snippet on the top right
- Verify `cs:trusty/nagios-7` is copied to your system clipboard