### PR TITLE
Remove OIL program from the site

### DIFF
--- a/templates/jaasai/community.html
+++ b/templates/jaasai/community.html
@@ -111,19 +111,9 @@
 <div class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2>Juju partner programmes</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-6">
-      <h4>Charm Partner Programme</h4>
+      <h2>Charm Partner Programmes</h2>
       <p>The Charm Partner Programme will help you to get your solution into the Charm Store, giving new benefits to your current customers, as well as accessing new potential users.</p>
       <p><a href="/community/partners">Learn more&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-6">
-      <h4>OpenStack Interoperability Lab</h4>
-      <p>The Ubuntu OpenStack Interoperability Lab (OIL) is an integration lab where Canonical tests our cloud partners products in countless Ubuntu OpenStack configurations, over and over again.</p>
-      <p><a href="/community/partners/#oil-for-apps">Learn more&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>

--- a/templates/jaasai/community/partners.html
+++ b/templates/jaasai/community/partners.html
@@ -6,24 +6,11 @@
 <div class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h1>Juju Partner Programmes</h1>
-      <h3>Tap into the leading cloud ecosystem</h3>
-      <p>Ubuntu is the world&rsquo;s most popular platform for OpenStack deployments and the most commonly deployed guest operating system on all the major public clouds. As such, it represents a tremendous revenue opportunity for solution providers. By joining one of our software programmes, you can exploit the cost and speed benefits that have made Ubuntu and its ecosystem a mainstay in the age of the cloud.</p>
+      <h1>Charm Partner Programme</h1>
+      <p>The Charm Partner Programme will help you to get your solution into the Charm Store, giving new benefits to your current customers, as well as accessing new potential users. You will receive training and support, as well as co marketing opportunities to help promote your solution to the Ubuntu Cloud Ecosystem.</p>
     </div>
     <div class="col-4 u-hide--small">
       <img src="/static/img/partners/image-partnering.png" alt="Juju partners pictogram" />
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Charm Partner Programme</h2>
-      <p>The Charm Partner Programme will help you to get your solution into the Charm Store, giving new benefits to your current customers, as well as accessing new potential users. You will receive training and support, as well as co marketing opportunities to help promote your solution to the Ubuntu Cloud Ecosystem.</p>
-    </div>
-    <div class="col-4 u-align--center u-vertically-centered">
-      <img width="180" height="180" src="/static/img/pictograms/picto-juju.svg" alt="">
     </div>
   </div>
 </div>
@@ -56,48 +43,6 @@
   <div class="row">
     <div class="col-12 u-align--center">
       <a href="http://partners.ubuntu.com/partner-programmes/software#charm-partner-programme" class="p-button--neutral">Find out more</a>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip--light">
-  <div class="row">
-    <div class="col-6">
-      <h2>OIL for apps</h2>
-      <p>The Ubuntu OpenStack Interoperability Lab (OIL) is an integration lab where Canonical tests our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, over and over again. Currently we are running over 3,000 combinations per month. OIL offers significant benefits for partners looking to QA their products quickly and cost-effectively, ensuring they are are compatible with all versions of Ubuntu OpenStack on a wide variety of server, storage, networking and software infrastructure products. Canonical provides interoperability testing for software which provides/extends the Nova, Neutron, Swift, Cinder, and Trove OpenStack components, as well as for applications that run in an OpenStack-based Cloud model.</p>
-    </div>
-    <div class="col-6 u-align--center">
-      <img src="/static/img/partners/image-ubuntuopenstack.svg" class="right not-for-small" alt="" />
-    </div>
-  </div>
-</div>
-
-<div class="p-strip--light">
-    <div class="row">
-      <div class="col-12">
-        <h3>Benefits of the programme include:</h3>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-6">
-        <ul class="p-list--divided">
-          <li class="p-list__item">Automated installation and interoperability testing of software in the Ubuntu OpenStack Interoperability Lab (OIL), including charm compatibility testing</li>
-          <li class="p-list__item">Interoperability testing on market-leading servers, networking and storage hardware and software products</li>
-          <li class="p-list__item">Licenses for up to three Landscape Dedicated Servers for systems management</li>
-        </ul>
-      </div>
-      <div class="col-6">
-        <ul class="p-list--divided">
-          <li class="p-list__item">Marketing assistance, including entry into our list of compatible solutions, joint revenue opportunities and support for joint solutions</li>
-          <li class="p-list__item">Training on the creation, adaptation and real-world use of Juju Charms, plus entry into the repository of Juju solutions</li>
-          <li class="p-list__item">Priority access to Ubuntu engineers and the Canonical Cloud and Server Roadmap</li>
-        </ul>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12 u-align--center">
-        <a href="http://partners.ubuntu.com/partner-programmes/openstack" class="p-button--neutral">Find out more</a>
-      </div>
     </div>
   </div>
 </div>

--- a/templates/jaasai/openstack.html
+++ b/templates/jaasai/openstack.html
@@ -32,7 +32,7 @@
       </div>
       <div class="col-3">
         <h3>Agility</h3>
-        <p>Experiment with different versions, configurations and solutions to choose what works for you. <a href="/community/partners#oil-for-apps">The OpenStack Interoperability Lab</a> ensures all components can be combined reliably in real-world deployments.</p>
+        <p>Experiment with different versions, configurations and solutions to choose what works for you.</p>
       </div>
       <div class="col-3">
         <h3>Support</h3>


### PR DESCRIPTION
## Done

- Removed mentions of OIL from /openstack, /community and /community/partners as the programme is dead
- Updated the copy doc

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/openstack, http://0.0.0.0:8029/community and http://0.0.0.0:8029/community/partners
- Compare to the copy docs:
    - [/community](https://docs.google.com/document/d/1ZwmQ6XkUxLSfhlKSN-jhkcGpqRWx-h8EX_1VVE5-xd4/edit#)
    - [/community/partners](https://docs.google.com/document/d/1oSB-4ARVBRqsMYE8R4lHsTGBvLh0FsogktpZ3rrYEGc/edit#)
    - [/openstack](https://docs.google.com/document/d/1dwEVOARtzVXV4035xlxHfeTeaknv_iTy_3e_oE5SN1A/edit#)

## Details

Fixes #61

