### PR TITLE
Don't show the login in the global nav

### DIFF
--- a/static/js/src/app.js
+++ b/static/js/src/app.js
@@ -4,6 +4,6 @@ import showContactDetails from './modules/show-contact-details';
 import copySnippet from './modules/copy-snippet';
 
 // Instantiate modules
-createNav({maxWidth: '64.875rem'});
+createNav({maxWidth: '64.875rem', showLogins: false});
 showContactDetails();
 copySnippet();


### PR DESCRIPTION
## Done

- Remove the login link from the global nav. 

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check that there is no login link in the top right of the global nav.

## Details

- Fixes: #65.
