### PR TITLE
Set Spicule logo size on the homepage

### DIFF
--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -62,7 +62,7 @@
             <p>Spicule's <a class="p-link--strong" href="https://jujucharms.com/u/spiculecharms/saiku-drill/">Saiku solution</a> can solve your Big Data challenge.</p>
             <div class="p-card card-wrap u-align--center u-vertically-center">
               <a href="/experts/spicule">
-                <img class="u-no-padding--bottom" style="padding-bottom:0.5rem" src="/static/img/logos/spicule.png" alt="Spicule logo" />
+                <img class="u-no-padding--bottom" style="padding-bottom:0.5rem" src="/static/img/logos/spicule.png" alt="Spicule logo" width="160" />
               </a>
             </div>
             <a href="https://jujucharms.com/u/spiculecharms/saiku-drill/" class="p-button--positive">

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -62,7 +62,7 @@
             <p>Spicule's <a class="p-link--strong" href="https://jujucharms.com/u/spiculecharms/saiku-drill/">Saiku solution</a> can solve your Big Data challenge.</p>
             <div class="p-card card-wrap u-align--center u-vertically-center">
               <a href="/experts/spicule">
-                <img class="u-no-padding--bottom" style="padding-bottom:0.5rem" src="/static/img/logos/spicule.png" alt="Spicule logo" width="160" />
+                <img style="padding:1rem 0" src="/static/img/logos/spicule.png" alt="Spicule logo" width="160" />
               </a>
             </div>
             <a href="https://jujucharms.com/u/spiculecharms/saiku-drill/" class="p-button--positive">


### PR DESCRIPTION
## Done

- Correctly set the Spicule logo size on homepage

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check that the size of the Spicule logo (in the JUJU EXPERT PARTNERS block) is the same size as on jujucharms.com.

## Details

- Fixes: #41.
