### PR TITLE
Increase the nav breakpoint

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -5,6 +5,10 @@ $asset-path: '/static/';
 // Override local variables
 $color-navigation-background: #333;
 
+// Set the mobile nav breakpoint to handle the large number of nav items.
+@import 'vanilla-framework/scss/settings_breakpoints';
+$breakpoint-navigation-threshold: $breakpoint-large;
+
 // Import Vanilla Framework
 @import 'vanilla-framework/scss/vanilla';
 


### PR DESCRIPTION
## Done

- Set the mobile nav breakpoint to handle the high number of nav items as well as the search box that is being added.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Reduce your browser size until the content width starts to decrease. At this point the mobile nav should appear.

## Details

- Fixes: #66.
