### PR TITLE
Improve search performance

### DIFF
--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -149,7 +149,6 @@ def _parse_charm_data(charm_data, include_files=False):
         'bzr_url': bzr_url,
         'charm_data': charm_data,
         'display_name': _get_display_name(name),
-        # 'files': _get_entity_files(ref, meta.get('manifest')),
         'homepage': homepage,
         'icon': cs.charm_icon_url(charm_id),
         'id': charm_id,


### PR DESCRIPTION
## Done

- Improve performance by only getting the files when needed (search and profile pages now take ~1 second instead of ~30 seconds).

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Do a search from the header. It should take about 1-2 seconds.
- Open a users profile. It should take about 1-2 seconds.
- View a charm. The readme should be visible and there should be a list of files on the right hand side.
- View a bundle. The readme should be visible.
