### PR TITLE
Add sorting and filtering

### DIFF
--- a/static/sass/custom/_search-results.scss
+++ b/static/sass/custom/_search-results.scss
@@ -21,6 +21,53 @@
   }
 }
 
+.filter-row {
+  margin: 1rem auto;
+
+  .list-block__filters--selects {
+    &-item {
+      float: left;
+      margin-left: 0;
+      width: 50%;
+    }
+
+    label {
+      padding-right: 1rem;
+      text-align: right;
+
+      @media (min-width: $breakpoint-medium) {
+        padding-right: 2rem;
+        padding-top: 0;
+      }
+    }
+  }
+
+  .p-inline-list__item {
+    cursor: pointer;
+  }
+
+  @media (min-width: $breakpoint-medium) {
+    select {
+      margin-left: -1.5rem;
+      margin-top: -0.5rem;
+    }
+
+    .is-selected {
+      position: relative;
+
+      &::after {
+        background: $color-mid-dark;
+        bottom: -0.25rem;
+        content: ' ';
+        height: 3px;
+        left: 0;
+        position: absolute;
+        width: 100%;
+      }
+    }
+  }
+}
+
 .entity-icon {
   border-radius: 50%;
 }

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -41,11 +41,11 @@
           </h1>
           <ul class="p-media-object__meta-list u-no-margin--bottom">
               <li class="p-media-object__meta-list-item u-no-padding--left">
-                <strong>By</strong> <a href="https://jujucharms.com/u/{{ context.charm.charm_data['Meta']['owner']['User'] }}">{{ context.charm.charm_data['Meta']['owner']['User'] }}</a>
+                <strong>By</strong> <a href="/u/{{ context.charm.charm_data['Meta']['owner']['User'] }}">{{ context.charm.charm_data['Meta']['owner']['User'] }}</a>
               </li>
               <li class="p-media-object__meta-list-item u-no-padding--left">
                 {% if context.charm.revision_number != context.charm.latest_revision['id'] %}
-                  <a href="https://jujucharms.com/{{ context.charm.latest_revision['url'] }}"
+                  <a href="/{{ context.charm.latest_revision['url'] }}"
                     onclick="dataLayer.push({
                       'event' : 'GAEvent',
                       'eventCategory' : 'Charm Details Link',
@@ -78,7 +78,7 @@
       </div>
       <p>
         {% set new_model_url = "/new/?deploy-target=" + context.charm.id %}
-        <a href="https://jujucharms.com{{ new_model_url }}" class="p-button--positive row" rel="nofollow">
+        <a href="/{{ new_model_url }}" class="p-button--positive row" rel="nofollow">
           Add to new model
         </a>
       </p>
@@ -116,7 +116,7 @@
         <ul class="p-inline-list">
           <li class="p-inline-list__item"><strong>Tags:</strong></li>
           {% for tag in context.charm.charm_data['Meta']['charm-metadata']['Tags'] %}
-            <li class="p-inline-list__item"><a href="https://jujucharms.com/q?tags={{ tag }}">{{ tag }}&nbsp;&rsaquo;</a></li>
+            <li class="p-inline-list__item"><a href="/search?tags={{ tag }}">{{ tag }}&nbsp;&rsaquo;</a></li>
           {% endfor %}
         </ul>
       {% endif %}
@@ -205,7 +205,7 @@
             {% for resourcename, resourcefile in context.charm.resources.items() %}
               <li class="p-list__item">
               {% if resourcefile[1] %}
-                  <a href='https://jujucharms.com{{resourcefile[1]}}' target='_blank'>{{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}</a>
+                  <a href='/{{resourcefile[1]}}' target='_blank'>{{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}</a>
               {% else %}
                   {{ resourcename }} {% if resourcefile[0] %}({{ resourcefile[0] }}) {% endif %}
               {% endif %}
@@ -228,14 +228,14 @@
             {% if context.charm.requires %}
               {% for name, value in context.charm.requires.items() %}
                 <li class="p-list__item">
-                  <a target="_blank" href="https://jujucharms.com/q/?provides={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
+                  <a target="_blank" href="/search/?provides={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
                 </li>
               {% endfor %}
             {% endif %}
             {% if context.charm.provides %}
               {% for name, value in context.charm.provides.items() %}
                 <li class="p-list__item">
-                  <a target="_blank" href="https://jujucharms.com/q?requires={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
+                  <a target="_blank" href="/search?requires={{ value.Interface }}" >{{ name }}: {{ value.Interface }}</a>
                 </li>
               {% endfor %}
             {% endif %}

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -44,7 +44,7 @@
     <div class="p-strip">
       <div class="row">
         <div class="col-12 search-results__overview">
-          Your search for <strong>&lsquo;{{ context.query }}&rsquo;</strong> returned
+          Your search {% if context.query %}for <strong>&lsquo;{{ context.query }}&rsquo;</strong>{% endif %} returned
           {{ context.results_count }} result{{ context.results_count|pluralize }}.
         </div>
       </div>

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -4,80 +4,224 @@
 
 {% block content %}
 {% if context.results_count > 0 %}
-  <div class="p-strip">
-    <div class="row">
-      <div class="col-12 search-results__overview">
-        Your search for <strong>&lsquo;{{ context.query }}&rsquo;</strong> returned
-        {{ context.results_count }} result{{ context.results_count|pluralize }}.
-      </div>
-    </div>
-  </div>
+  {% macro full_series(series) -%}
+    {% if series|lower == 'oneiric' %}
+      Oneiric 11.10
+    {% elif series|lower == 'precise' %}
+      Precise 12.04
+    {% elif series|lower == 'quantal' %}
+      Quantal 12.10
+    {% elif series|lower == 'raring' %}
+      Raring 13.04
+    {% elif series|lower == 'saucy' %}
+      Saucy 13.10
+    {% elif series|lower == 'trusty' %}
+      Trusty 14.04
+    {% elif series|lower == 'utopic' %}
+      Utopic 14.10
+    {% elif series|lower == 'vivid' %}
+      Vivid 15.04
+    {% elif series|lower == 'wily' %}
+      Wily 15.10
+    {% elif series|lower == 'xenial' %}
+      Xenial 16.04
+    {% elif series|lower == 'yakkety' %}
+      Yakkety 16.10
+    {% elif series|lower == 'zesty' %}
+      Zesty 17.04
+    {% elif series|lower == 'artful' %}
+      Artful 17.10
+    {% elif series|lower == 'bionic' %}
+      Bionic 18.04
+    {% elif series|lower == 'cosmic' %}
+      Cosmic 18.10
+    {% else %}
+      {{ series|capitalize }}
+    {% endif %}
+  {%- endmacro %}
 
-  {% if context.results.recommended %}
-    <div class="row">
-      <h4>
-        Recommended
-        <span class="count">
-          ({{ context.results.recommended|length }})
-        </span>
-      </h4>
-      <table class="search-results-table">
-        <tbody>
-          {% for entity in context.results.recommended %}
-            <tr class="{{ entity.type }} u-no-padding--top">
-              {% with %}
-                {% set outerloop = loop %}
-                {% include "store/_search_row.html" %}
-              {% endwith %}
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  {% endif %}
-
-  {% if context.results.community %}
-    {% if context.results.recommended %}
+  {% if context.query %}
+    <div class="p-strip">
       <div class="row">
-        <div class="col-12 u-align--center">
-          <button class="p-button--neutral js-show-community-results">
-            Show {{ context.results.community|length }} community results
-          </button>
+        <div class="col-12 search-results__overview">
+          Your search for <strong>&lsquo;{{ context.query }}&rsquo;</strong> returned
+          {{ context.results_count }} result{{ context.results_count|pluralize }}.
         </div>
       </div>
-    {% endif %}
-    <div class="row {% if context.results.recommended %}u-hide community-results{% endif %}">
-      <div class="col-12">
-        <h4>Community <span class="count">({{ context.results.community|length }})</span></h4>
-        <table class="search-results-table">
-          <tbody>
-            {% for entity in context.results.community %}
-            <tr class="{{ entity.type }} u-no-padding--top">
-              {% with %}
-                {% set outerloop = loop %}
-                {% include "store/_search_row.html" %}
-              {% endwith %}
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      {% if context.results.recommended %}
-        <script type="text/javascript">
-          var button = document.querySelector('.js-show-community-results');
-          var results = document.querySelector('.community-results');
-          button.addEventListener('click', function (e) {
-            results.classList.toggle('u-hide');
-            if (results.classList.contains('u-hide')) {
-              button.innerText = 'Show {{ context.results.community|length }} community results';
-            } else {
-              button.innerText = 'Hide community results';
-            }
-          });
-        </script>
-      {% endif %}
     </div>
   {% endif %}
+  <div class="row filter-row">
+     <div class="col-4">
+       <ul class="p-inline-list entitity-search-selector">
+         <li class="p-inline-list__item {% if context.current_type == None %}is-selected{% endif %}"
+             data-type="all" tabindex="0" role="button">
+             All
+         </li>
+         <li class="p-inline-list__item {% if context.current_type == 'charm' %}is-selected{% endif %}"
+             data-type="charm" tabindex="0" role="button">
+             Charms
+         </li>
+         <li class="p-inline-list__item {% if context.current_type == 'bundle' %}is-selected{% endif %}"
+             data-type="bundle" tabindex="0" role="button">
+             Bundles
+         </li>
+       </ul>
+     </div>
+     <div class="col-8">
+       <div class="list-block__filters--selects u-clearfix">
+         <form>
+           <div class="col-4">
+             <div class="list-block__filters--selects-item">
+               <label for="sort-select">
+                 Sort by:
+               </label>
+             </div>
+             <div class="list-block__filters--selects-item">
+               <select name="sort-select" class="js-sort-select">
+               <option value="-downloads" {% if context.current_sort == '-downloads' %}selected="selected"{% endif %}>
+                 Most popular
+               </option>
+               <option value="downloads" {% if context.current_sort == 'downloads' %}selected="selected"{% endif %}>
+                 Least popular
+               </option>
+               <option value="name" {% if context.current_sort == 'name' %}selected="selected"{% endif %}>
+                 Name (a-z)
+               </option>
+               <option value="-name" {% if context.current_sort == '-name' %}selected="selected"{% endif %}>
+                 Name (z-a)
+               </option>
+               <option value="owner" {% if context.current_sort == 'owner' %}selected="selected"{% endif %}>
+                 Author (a-z)
+               </option>
+               <option value="-owner" {% if context.current_sort == '-owner' %}selected="selected"{% endif %}>
+                 Author (z-a)
+               </option>
+             </select>
+             </div>
+           </div>
+           <div class="col-4">
+             <div class="list-block__filters--selects-item">
+               <label for="series-select">
+                 Series:
+               </label>
+             </div>
+             <div class="list-block__filters--selects-item">
+               <select class="js-series-select">
+               {# The series list has been limited to sane options, full list is here:
+               https://github.com/juju/charmstore/blob/v5-unstable/internal/router/router.go#L33  #}
+               {% for series in ['all', 'precise', 'trusty', 'xenial', 'bionic', 'centos7'] %}
+                 <option value="{{ series }}"
+                   {% if context.current_series == series %}selected="selected"{% endif %}>
+                   {{ full_series(series) }}
+                 </option>
+               {% endfor %}
+             </select>
+             </div>
+           </div>
+         </form>
+       </div>
+     </div>
+   </div>
+   {% if context.results.recommended %}
+     <div class="row">
+       <h4>
+         Recommended
+         <span class="count">
+           ({{ context.results.recommended|length }})
+         </span>
+       </h4>
+       <table class="search-results-table">
+         <tbody>
+           {% for entity in context.results.recommended %}
+             <tr class="{{ entity.type }} u-no-padding--top">
+               {% with %}
+                 {% set outerloop = loop %}
+                 {% include "store/_search_row.html" %}
+               {% endwith %}
+             </tr>
+           {% endfor %}
+         </tbody>
+       </table>
+     </div>
+   {% endif %}
+
+   {% if context.results.community %}
+     {% if context.results.recommended %}
+       <div class="row">
+         <div class="col-12 u-align--center">
+           <button class="p-button--neutral js-show-community-results">
+             Show {{ context.results.community|length }} community results
+           </button>
+         </div>
+       </div>
+     {% endif %}
+     <div class="row {% if context.results.recommended %}u-hide community-results{% endif %}">
+       <div class="col-12">
+         <h4>Community <span class="count">({{ context.results.community|length }})</span></h4>
+         <table class="search-results-table">
+           <tbody>
+             {% for entity in context.results.community %}
+             <tr class="{{ entity.type }} u-no-padding--top">
+               {% with %}
+                 {% set outerloop = loop %}
+                 {% include "store/_search_row.html" %}
+               {% endwith %}
+             </tr>
+             {% endfor %}
+           </tbody>
+         </table>
+       </div>
+       {% if context.results.recommended %}
+         <script type="text/javascript">
+           var button = document.querySelector('.js-show-community-results');
+           var results = document.querySelector('.community-results');
+           button.addEventListener('click', function (e) {
+             results.classList.toggle('u-hide');
+             if (results.classList.contains('u-hide')) {
+               button.innerText = 'Show {{ context.results.community|length }} community results';
+             } else {
+               button.innerText = 'Hide community results';
+             }
+           });
+         </script>
+       {% endif %}
+     </div>
+   {% endif %}
+
+  <script>
+    /**
+     * Change the sort order of the search results.
+     * @param {String} type the type of filter to change.
+     * @param {String} value the new filter value.
+     */
+    function _searchChangeFilter(type, value) {
+      const url = window.location.href.split('?')[0];
+      const queries = {};
+      window.location.search.substr(1).split('&').forEach(ele => {
+        const parts = ele.split('=');
+        if (parts[0]) {
+          queries[parts[0]] = parts[1];
+        }
+      })
+      // No need to change the url if the filter value is already selected.
+      if (value !== queries[type]) {
+        if ((type === 'series' || type === 'type') && value === 'all') {
+          delete queries[type];
+        } else {
+          queries[type] = value;
+        }
+        const queryString = Object.keys(queries).map(key => `${key}=${queries[key]}`).join('&');
+        window.location = `${url}?${queryString}`;
+      }
+    }
+    document.querySelector('.js-sort-select')
+      .addEventListener('change', e => _searchChangeFilter('sort', e.target.value));
+    document.querySelector('.js-series-select')
+      .addEventListener('change', e => _searchChangeFilter('series', e.target.value));
+    document
+      .querySelectorAll('.entitity-search-selector li')
+      .forEach(ele => ele.addEventListener('click', e => _searchChangeFilter('type', e.target.dataset.type)));
+  </script>
 {% else %}
   <div class="p-strip">
     <div class="row">

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -6,25 +6,15 @@ from webapp.store import models
 
 
 class TestStoreModels(unittest.TestCase):
-    @patch('theblues.charmstore.CharmStore.files')
-    @patch('theblues.charmstore.CharmStore.entity_readme_content')
     @patch('theblues.charmstore.CharmStore.search')
-    def test_search_entities(self, mock_search, mock_entity_readme_content,
-                             mock_files):
-        mock_entity_readme_content.return_value = ''
-        mock_files.return_value = ''
+    def test_search_entities(self, mock_search):
         mock_search.return_value = search_data
         results = models.search_entities('apache2')
         self.assertEqual(len(results['community']), 8)
         self.assertEqual(len(results['recommended']), 2)
 
-    @patch('theblues.charmstore.CharmStore.files')
-    @patch('theblues.charmstore.CharmStore.entity_readme_content')
     @patch('theblues.charmstore.CharmStore.search')
-    def test_search_entities_none(self, mock_search,
-                                  mock_entity_readme_content, mock_files):
-        mock_entity_readme_content.return_value = ''
-        mock_files.return_value = ''
+    def test_search_entities_none(self, mock_search):
         mock_search.return_value = []
         results = models.search_entities('apache2')
         self.assertEqual(len(results['community']), 0)

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -16,11 +16,29 @@ def store():
 
 @jaasstore.route('/search/')
 def search():
-    query = request.args.get('q').replace('/', ' ')
-    results = models.search_entities(query)
+    query = request.args.get('q', '').replace('/', ' ')
+    entity_type = request.args.get('type', None)
+    if entity_type not in ['charm', 'bundle']:
+        entity_type = None
+    series = request.args.get('series', None)
+    tags = request.args.get('tags', None)
+    sort = request.args.get('sort', None)
+    provides = request.args.get('provides', None)
+    requires = request.args.get('requires', None)
+    if provides:
+        results = models.fetch_provides(provides)
+    elif requires:
+        results = models.fetch_requires(requires)
+    else:
+        results = models.search_entities(query, entity_type=entity_type, tags=tags,
+                                     sort=sort, series=series,
+                                     promulgated_only=False)
     return render_template(
         'store/search.html',
         context={
+            'current_series': series,
+            'current_sort': sort,
+            'current_type': entity_type,
             'results': results,
             'results_count':
                 len(results['recommended']) + len(results['community']),

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -30,9 +30,9 @@ def search():
     elif requires:
         results = models.fetch_requires(requires)
     else:
-        results = models.search_entities(query, entity_type=entity_type, tags=tags,
-                                     sort=sort, series=series,
-                                     promulgated_only=False)
+        results = models.search_entities(query, entity_type=entity_type,
+                                         tags=tags, sort=sort, series=series,
+                                         promulgated_only=False)
     return render_template(
         'store/search.html',
         context={


### PR DESCRIPTION
## Done

- Add functionality for sorting and filtering search results.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Do a search. Use the controls to sort and filter the results.
- View a charm and click on a tag. You should see search results for that tag.
- View a charm and click on a relation in the Relations box on the right hand side. You should see search results for that relation.

## Details

- Fixes: #56.
- Fixes: #57.
- Fixes: #58.
