### PR TITLE
Redirect searches

### DIFF
--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -30,6 +30,30 @@ class StoreViews(TestCase):
         response = self.client.get('/search?q=k8s')
         self.assertEqual(response.status_code, 200)
 
+    @patch('webapp.store.models.search_entities')
+    def test_search_redirect(self, mock_search_entities):
+        mock_search_entities.return_value = []
+        response = self.client.get('/q/k8s')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, 'http://localhost/search?q=k8s')
+
+    @patch('webapp.store.models.search_entities')
+    def test_search_redirect_multi_word(self, mock_search_entities):
+        mock_search_entities.return_value = []
+        response = self.client.get('/q/k8s/demo')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location, 'http://localhost/search?q=k8s+demo')
+
+    @patch('webapp.store.models.search_entities')
+    def test_search_redirect_query_params(self, mock_search_entities):
+        mock_search_entities.return_value = []
+        response = self.client.get('/q/k8s?sort=name&series=xenial')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location,
+            'http://localhost/search?q=k8s&sort=name&series=xenial')
+
     @patch('webapp.store.models.get_user_entities')
     def test_user_details(self, mock_get_user_entities):
         mock_get_user_entities.return_value = {

--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -54,6 +54,14 @@ class StoreViews(TestCase):
             response.location,
             'http://localhost/search?q=k8s&sort=name&series=xenial')
 
+    @patch('webapp.store.models.search_entities')
+    def test_search_redirect_just_query_params(self, mock_search_entities):
+        mock_search_entities.return_value = []
+        response = self.client.get('/q?tags=proxy')
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location, 'http://localhost/search?tags=proxy')
+
     @patch('webapp.store.models.get_user_entities')
     def test_user_details(self, mock_get_user_entities):
         mock_get_user_entities.return_value = {

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, abort, request, render_template
+from flask import Blueprint, abort, redirect, request, render_template
 from webapp.store import models
 
 from jujubundlelib import references
@@ -27,6 +27,19 @@ def search():
             'query': query
         }
     )
+
+
+@jaasstore.route('/q/<path:path>')
+def search_redirect(path):
+    """
+    Handle redirects from jujucharms.com search URLS to the jaas.ai format.
+    e.g. /q/k8s/demo?sort=-name&series=xenial will redirect to
+    /search?q=k8s+demo&sort=-name&series=xenial
+    """
+    query_string = ['q={}'.format(path.replace('/', '+'))]
+    if request.query_string:
+        query_string.append(str(request.query_string, 'utf-8'))
+    return redirect('/search?{}'.format('&'.join(query_string)), code=302)
 
 
 @jaasstore.route('/u/<username>/')

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -29,14 +29,17 @@ def search():
     )
 
 
+@jaasstore.route('/q/')
 @jaasstore.route('/q/<path:path>')
-def search_redirect(path):
+def search_redirect(path=None):
     """
     Handle redirects from jujucharms.com search URLS to the jaas.ai format.
     e.g. /q/k8s/demo?sort=-name&series=xenial will redirect to
     /search?q=k8s+demo&sort=-name&series=xenial
     """
-    query_string = ['q={}'.format(path.replace('/', '+'))]
+    query_string = []
+    if path:
+        query_string.append('q={}'.format(path.replace('/', '+')))
     if request.query_string:
         query_string.append(str(request.query_string, 'utf-8'))
     return redirect('/search?{}'.format('&'.join(query_string)), code=302)


### PR DESCRIPTION
## Done

- Handle redirects of jujucharms.com style search urls.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Do some searches using the URL format used on jujucharms.com e.g. `/q/k8s/demo?sort=-name&series=xenial`.
- You should be redirected to the new jaas.ai search URL format.
