### PR TITLE
Show search count

### DIFF
--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -40,16 +40,14 @@
     {% endif %}
   {%- endmacro %}
 
-  {% if context.query %}
-    <div class="p-strip">
-      <div class="row">
-        <div class="col-12 search-results__overview">
-          Your search {% if context.query %}for <strong>&lsquo;{{ context.query }}&rsquo;</strong>{% endif %} returned
-          {{ context.results_count }} result{{ context.results_count|pluralize }}.
-        </div>
+  <div class="p-strip">
+    <div class="row">
+      <div class="col-12 search-results__overview">
+        Your search {% if context.query %}for <strong>&lsquo;{{ context.query }}&rsquo;</strong>{% endif %} returned
+        {{ context.results_count }} result{{ context.results_count|pluralize }}.
       </div>
     </div>
-  {% endif %}
+  </div>
   <div class="row filter-row">
      <div class="col-4">
        <ul class="p-inline-list entitity-search-selector">


### PR DESCRIPTION
## Done

- Show the search count when there's not a query.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Visit a search URL that doesn't have a search term e.g. `/search?tags=app-servers`.
- You should see the results count at the top.
