### PR TITLE
Restore user urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build-css": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace 'static/css/**/*.css' --dir static/minified 'static/css/**/*.css'",
     "build-js": "webpack --mode development ./static/js/src/app.js --output ./static/js/dist/app.js --module-bind js=babel-loader",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
+    "format-python": "black --line-length 79 tests webapp",
     "lint-scss": "sass-lint static/**/*.scss --verbose --no-exit",
     "python-lint": "flake8 webapp tests && black --check --line-length 79 tests webapp",
     "serve": "./entrypoint 0.0.0.0:${PORT}",

--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -84,13 +84,13 @@ class StoreViews(TestCase):
         response = self.client.get("/u/user-name")
         self.assertEqual(response.status_code, 404)
 
-    """Check that a provided URL renders an entity page.
-
-    :param unittest.mock.MagicMock mock_entity: A mocked entity method.
-    :param str entity_type: Whether this entity is a charm or bundle.
-    :param str url: The URL to test.
-    """
     def check_entity(self, mock_entity, entity_type, url):
+        """Check that a provided URL renders an entity page.
+
+        :param unittest.mock.MagicMock mock_entity: A mocked entity method.
+        :param str entity_type: Whether this entity is a charm or bundle.
+        :param str url: The URL to test.
+        """
         return_value = charm_data if entity_type == "charm" else bundle_data
         mock_entity.return_value = return_value
         response = self.client.get(url)

--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -84,6 +84,12 @@ class StoreViews(TestCase):
         response = self.client.get("/u/user-name")
         self.assertEqual(response.status_code, 404)
 
+    """Check that a provided URL renders an entity page.
+
+    :param unittest.mock.MagicMock mock_entity: A mocked entity method.
+    :param str entity_type: Whether this entity is a charm or bundle.
+    :param str url: The URL to test.
+    """
     def check_entity(self, mock_entity, entity_type, url):
         return_value = charm_data if entity_type == "charm" else bundle_data
         mock_entity.return_value = return_value

--- a/tests/store/test_views.py
+++ b/tests/store/test_views.py
@@ -84,24 +84,90 @@ class StoreViews(TestCase):
         response = self.client.get("/u/user-name")
         self.assertEqual(response.status_code, 404)
 
-    @patch("theblues.charmstore.CharmStore.entity")
-    def test_details_charm(self, mock_entity):
-        mock_entity.return_value = charm_data
-        response = self.client.get("/apache2")
+    def check_entity(self, mock_entity, entity_type, url):
+        return_value = charm_data if entity_type == "charm" else bundle_data
+        mock_entity.return_value = return_value
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         context = self.get_context_variable("context")
         self.assertIsNotNone(context["entity"])
 
     @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_charm(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/apache2")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_charm_version(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/apache2/14")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_charm_series(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/apache2/wily")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_charm_series_version(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/apache2/wily/14")
+
+    @patch("theblues.charmstore.CharmStore.entity")
     def test_details_bundle(self, mock_entity):
-        mock_entity.return_value = bundle_data
-        response = self.client.get("/k8s-bundle")
-        self.assertEqual(response.status_code, 200)
-        context = self.get_context_variable("context")
-        self.assertIsNotNone(context["entity"])
+        self.check_entity(mock_entity, "bundle", "/k8s-bundle")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_bundle_version(self, mock_entity):
+        self.check_entity(mock_entity, "bundle", "/k8s-bundle/14")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_bundle_series(self, mock_entity):
+        self.check_entity(mock_entity, "bundle", "/k8s-bundle/wily")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_details_bundle_series_version(self, mock_entity):
+        self.check_entity(mock_entity, "bundle", "/k8s-bundle/wily/14")
 
     @patch("webapp.store.models.get_charm_or_bundle")
     def test_details_404(self, mock_get_charm_or_bundle):
         mock_get_charm_or_bundle.return_value = None
         response = self.client.get("/nothing")
         self.assertEqual(response.status_code, 404)
+
+    @patch("webapp.store.models.get_charm_or_bundle")
+    def test_user_entity_404(self, mock_get_charm_or_bundle):
+        mock_get_charm_or_bundle.return_value = None
+        response = self.client.get("/u/user-name/no-thing")
+        self.assertEqual(response.status_code, 404)
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_charm(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/u/user-name/apache2")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_charm_version(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/u/user-name/apache2/14")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_charm_series(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/u/user-name/apache2/wily")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_charm_series_version(self, mock_entity):
+        self.check_entity(mock_entity, "charm", "/u/user-name/apache2/wily/14")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_bundle(self, mock_entity):
+        self.check_entity(mock_entity, "bundle", "/u/user-name/k8s-bundle")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_bundle_version(self, mock_entity):
+        self.check_entity(mock_entity, "bundle", "/u/user-name/k8s-bundle/14")
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_bundle_series(self, mock_entity):
+        self.check_entity(
+            mock_entity, "bundle", "/u/user-name/k8s-bundle/wily"
+        )
+
+    @patch("theblues.charmstore.CharmStore.entity")
+    def test_user_entity_bundle_series_version(self, mock_entity):
+        self.check_entity(
+            mock_entity, "bundle", "/u/user-name/k8s-bundle/wily/14"
+        )

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -94,9 +94,13 @@ def user_details(username):
 @jaasstore.route(
     "/u/<username>/<charm_or_bundle_name>/<series_or_version>/<version>"
 )
-def user_entity(username, charm_or_bundle_name, series_or_version=None, version=None):
+def user_entity(
+    username, charm_or_bundle_name, series_or_version=None, version=None
+):
     return details(
-        charm_or_bundle_name, series_or_version=series_or_version, version=version
+        charm_or_bundle_name,
+        series_or_version=series_or_version,
+        version=version,
     )
 
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -91,7 +91,9 @@ def user_details(username):
 
 @jaasstore.route("/u/<username>/<charm_or_bundle_name>/")
 @jaasstore.route("/u/<username>/<charm_or_bundle_name>/<series_or_version>")
-@jaasstore.route("/u/<username>/<charm_or_bundle_name>/<series_or_version>/<version>")
+@jaasstore.route(
+    "/u/<username>/<charm_or_bundle_name>/<series_or_version>/<version>"
+)
 def user_entity(username, entity_name, series_or_version=None, version=None):
     return details(
         entity_name, series_or_version=series_or_version, version=version

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -94,9 +94,9 @@ def user_details(username):
 @jaasstore.route(
     "/u/<username>/<charm_or_bundle_name>/<series_or_version>/<version>"
 )
-def user_entity(username, entity_name, series_or_version=None, version=None):
+def user_entity(username, charm_or_bundle_name, series_or_version=None, version=None):
     return details(
-        entity_name, series_or_version=series_or_version, version=version
+        charm_or_bundle_name, series_or_version=series_or_version, version=version
     )
 
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -90,30 +90,12 @@ def user_details(username):
 
 
 @jaasstore.route("/u/<username>/<entity_name>/")
-def user_entity(username, entity_name):
-    reference = references.Reference.from_jujucharms_url(request.path[1:])
-    entity = models.get_charm_or_bundle(reference)
-
-    if entity:
-        if entity["is_charm"]:
-            entity["description"] = entity["charm_data"]["Meta"][
-                "charm-metadata"
-            ]["Description"]
-            entity["user"] = entity["charm_data"]["Meta"]["owner"]["User"]
-            return render_template(
-                "store/charm-details.html", context={"entity": entity}
-            )
-        else:
-            entity["user"] = entity["bundle_data"]["Meta"]["owner"]["User"]
-            entity["id"] = entity["bundle_data"]["Id"]
-            entity["meta_published_info"] = entity["bundle_data"]["Meta"][
-                "published"
-            ]["Info"]
-            return render_template(
-                "store/bundle-details.html", context={"entity": entity}
-            )
-    else:
-        return abort(404, "Entity not found {}".format())
+@jaasstore.route("/u/<username>/<entity_name>/<series_or_version>")
+@jaasstore.route("/u/<username>/<entity_name>/<series_or_version>/<version>")
+def user_entity(username, entity_name, series_or_version=None, version=None):
+    return details(
+        entity_name, series_or_version=series_or_version, version=version
+    )
 
 
 @jaasstore.route("/<charm_or_bundle_name>")
@@ -138,6 +120,7 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
             entity["description"] = entity["charm_data"]["Meta"][
                 "charm-metadata"
             ]["Description"]
+            entity["user"] = entity["charm_data"]["Meta"]["owner"]["User"]
             return render_template(
                 "store/charm-details.html", context={"entity": entity}
             )


### PR DESCRIPTION
## Done

- Restore the user entity URLs and add tests so we notice if these get broken/removed again in the future.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- View a user's profile. Click on some bundles and charms. They should load.
