### PR TITLE
Normalise model properties for templates

### DIFF
--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -15,11 +15,11 @@
         </h1>
       </div>
       <ul class="entity__meta p-inline-list--middot">
-        {% if context.entity.user %}
+        {% if context.entity.owner %}
           <li class="p-inline-list__item">
             <span class="entity__user">
               By <a
-                href="{{ url_for('jaasstore.user_details', username=context.entity.user) }}">{{ context.entity.user }}</a>
+                href="{{ url_for('jaasstore.user_details', username=context.entity.owner) }}">{{ context.entity.owner }}</a>
             </span>
           </li>
         {% endif %}

--- a/templates/store/_entity-header.html
+++ b/templates/store/_entity-header.html
@@ -37,11 +37,11 @@
             </span>
           </li>
         {% endif %}
-        {% if context.entity.meta_published_info %}
+        {% if context.entity.channels %}
           <li class="p-inline-list__item">
             <span class="entity__channel">
-              {% for meta_info in context.entity.meta_published_info %}
-              <span>{{ meta_info['Channel'] }}</span>{% if not loop.last %},{% endif %}
+              {% for channel in context.entity.channels %}
+              <span>{{ channel['Channel'] }}</span>{% if not loop.last %},{% endif %}
               {% endfor %}
             </span>
           </li>

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -9,10 +9,10 @@
 <div class="p-strip is-shallow">
   <div class="row">
     <div class="col-8">
-      {% if context.entity.bundle_data.description %}
+      {% if context.entity.description %}
         <div id="description" itemprop="description">
           <h3>Description</h3>
-          <p>{{ context.entity.bundle_data.description }}</p>
+          <p>{{ context.entity.description }}</p>
         </div>
       {% endif %}
       <div class="p-card--highlighted">

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -7,7 +7,7 @@
 {% block meta_tags %}
   <meta property="og:title" content="{{ context.entity.display_name }}" />
   <meta property="og:url" content="{{ request.current_route_url() }}" />
-  {% if description != '' %}
+  {% if context.entity.description != '' %}
     <meta property="og:description" content="{{ context.entity.description|striptags }}" />
   {% endif %}
   <meta property="og:image" content="{{ request.route_url('icon-proxy-resize', entity_name=name, size=120, file_type='png') }}" />
@@ -19,7 +19,7 @@
   <meta name="twitter:creator" content="@ubuntucloud">
   <meta name="twitter:title" content="{{ context.entity.display_name }} - Juju charm">
   <meta name="twitter:image" content="{{ request.route_url('icon-proxy-resize', entity_name=name, size=120, file_type='png') }}">
-  <meta name="twitter:description" content="{% if description %}{{ description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
+  <meta name="twitter:description" content="{% if context.entity.description %}{{ context.entity.description|striptags }}{% else %}Deploy {{ context.entity.display_name }} to public or private clouds or even bare metal using the Juju GUI or command line.{% endif %}">
   <link rel="canonical" href="{{ canonical_url }}" />
 {% endblock %}
 

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -1,6 +1,6 @@
 import unittest
 
-from tests.store.testdata import charm_data, search_data
+from tests.store.testdata import bundle_data, charm_data, search_data
 from unittest.mock import patch
 from webapp.store import models
 
@@ -20,6 +20,116 @@ class TestStoreModels(unittest.TestCase):
         self.assertEqual(len(results["community"]), 0)
         self.assertEqual(len(results["recommended"]), 0)
 
-    def test_parse_charm_data_tags(self):
+    def test_parse_charm_data(self):
         charm = models._parse_charm_data(charm_data)
+        self.assertEqual(
+            charm["archive_url"],
+            "https://api.jujucharms.com/v5/apache2-26/archive",
+        )
+        self.assertEqual(
+            charm["bugs_url"], "https://bugs.launchpad.net/apache2-charm"
+        )
+        self.assertIsNone(charm["bzr_url"])
+        self.assertEqual(charm["card_id"], "apache2-26")
+        self.assertEqual(
+            charm["channels"], [{"Channel": "stable", "Current": True}]
+        )
+        self.assertTrue(
+            "The Apache Software Foundation's goal" in charm["description"]
+        )
+        self.assertEqual(charm["display_name"], "apache2")
+        self.assertEqual(
+            charm["homepage"], "https://launchpad.net/apache2-charm"
+        )
+        self.assertEqual(
+            charm["icon"], "https://api.jujucharms.com/v5/apache2-26/icon.svg"
+        )
+        self.assertEqual(charm["id"], "cs:apache2-26")
+        self.assertTrue(charm["is_charm"])
+        self.assertIsNone(charm["latest_revision"])
+        self.assertEqual(
+            charm["options"].get("apt-key-id"),
+            {
+                "Type": "string",
+                "Description": (
+                    "A PGP key id.  This is used with PPA and the source "
+                    "option to import a PGP public key for verifying "
+                    "repository signatures. This value must match the PPA "
+                    "for apt-source."
+                ),
+                "Default": "",
+            },
+        )
+        self.assertEqual(charm["owner"], "apache2-charmers")
+        self.assertIsNone(charm["promulgated"])
+        self.assertEqual(
+            charm["provides"].get("apache-website"),
+            {
+                "Name": "apache-website",
+                "Role": "provider",
+                "Interface": "apache-website",
+                "Optional": False,
+                "Limit": 0,
+                "Scope": "container",
+            },
+        )
+        self.assertEqual(
+            charm["requires"].get("balancer"),
+            {
+                "Name": "balancer",
+                "Role": "requirer",
+                "Interface": "http",
+                "Optional": False,
+                "Limit": 1,
+                "Scope": "global",
+            },
+        )
+        self.assertEqual(charm["resources"], {})
+        self.assertIsNone(charm["revision_list"], "bob")
+        self.assertEqual(charm["revision_number"], 26)
+        self.assertEqual(len(charm["revisions"]), 10)
+        self.assertEqual(charm["series"], ["xenial", "trusty", "bionic"])
         self.assertEqual(charm["tags"], ["app-servers"])
+        self.assertEqual(charm["url"], "apache2/26")
+
+    def test_parse_bundle_data(self):
+        bundle = models._parse_bundle_data(bundle_data)
+        self.assertEqual(
+            bundle["archive_url"],
+            (
+                "https://api.jujucharms.com/v5/bundle/"
+                "canonical-kubernetes-466/archive"
+            ),
+        )
+        self.assertEqual(
+            bundle["bundle_visulisation"],
+            (
+                "https://api.jujucharms.com/v5/bundle/canonical-kubernetes-466"
+                "/diagram.svg"
+            ),
+        )
+        self.assertEqual(bundle["card_id"], "bundle/canonical-kubernetes-466")
+        self.assertEqual(
+            bundle["channels"],
+            [
+                {"Channel": "stable", "Current": True},
+                {"Channel": "candidate", "Current": False},
+                {"Channel": "beta", "Current": False},
+                {"Channel": "edge", "Current": False},
+            ],
+        )
+        self.assertEqual(
+            bundle["description"],
+            "A highly-available, production-grade Kubernetes cluster.",
+        )
+        self.assertEqual(bundle["display_name"], "canonical kubernetes")
+        self.assertEqual(bundle["id"], "cs:bundle/canonical-kubernetes-466")
+        self.assertFalse(bundle["is_charm"])
+        self.assertIsNone(bundle["latest_revision"])
+        self.assertEqual(bundle["owner"], "containers")
+        self.assertIsNone(bundle["promulgated"])
+        self.assertEqual(bundle["revision_number"], 466)
+        self.assertEqual(bundle["series"], ["bionic"])
+        self.assertIsNone(bundle["tags"])
+        self.assertEqual(bundle["units"], 10)
+        self.assertEqual(bundle["url"], "canonical-kubernetes/bundle/466")

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -129,15 +129,21 @@ def _parse_bundle_data(bundle_data, include_files=False):
         "bundle_data": bundle_data,
         "bundle_visulisation": getBundleVisualization(ref),
         "card_id": ref.path(),
+        "channels": meta.get("published", {}).get("Info"),
+        "description": bundle_metadata.get("Description"),
         "display_name": _get_display_name(name),
+        "id": bundle_data.get("Id"),
         "is_charm": False,
         "latest_revision": latest_revision,
         "owner": meta.get("owner", {}).get("User"),
         "promulgated": meta.get("promulgated", {}).get("Promulgated"),
         "revision_number": ref.revision,
+        # The series is an array to match the charm data.
+        "series": [bundle_metadata.get("Series")],
         "services": _parseBundleServices(bundle_metadata["applications"]),
         "tags": bundle_metadata.get("Tags"),
         "units": meta.get("bundle-unit-count", {}).get("Count", ""),
+        "user": meta.get("owner", {}).get("User"),
         "url": ref.jujucharms_id(),
     }
     if include_files:
@@ -179,7 +185,9 @@ def _parse_charm_data(charm_data, include_files=False):
         "archive_url": cs.archive_url(ref),
         "bugs_url": bugs_url,
         "bzr_url": bzr_url,
+        "channels": meta.get("published", {}).get("Info"),
         "charm_data": charm_data,
+        "description": charm_metadata.get("Description"),
         "display_name": _get_display_name(name),
         "homepage": homepage,
         "icon": cs.charm_icon_url(charm_id),
@@ -199,6 +207,7 @@ def _parse_charm_data(charm_data, include_files=False):
         # Some charms do not have tags, so fall back to categories if they
         # exist (mostly on older charms).
         "tags": charm_metadata.get("Tags") or charm_metadata.get("Categories"),
+        "user": meta.get("owner", {}).get("User"),
         "url": ref.jujucharms_id(),
         "is_charm": True,
     }

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -143,7 +143,6 @@ def _parse_bundle_data(bundle_data, include_files=False):
         "services": _parseBundleServices(bundle_metadata["applications"]),
         "tags": bundle_metadata.get("Tags"),
         "units": meta.get("bundle-unit-count", {}).get("Count", ""),
-        "user": meta.get("owner", {}).get("User"),
         "url": ref.jujucharms_id(),
     }
     if include_files:
@@ -185,6 +184,7 @@ def _parse_charm_data(charm_data, include_files=False):
         "archive_url": cs.archive_url(ref),
         "bugs_url": bugs_url,
         "bzr_url": bzr_url,
+        "card_id": ref.path(),
         "channels": meta.get("published", {}).get("Info"),
         "charm_data": charm_data,
         "description": charm_metadata.get("Description"),
@@ -192,7 +192,6 @@ def _parse_charm_data(charm_data, include_files=False):
         "homepage": homepage,
         "icon": cs.charm_icon_url(charm_id),
         "id": charm_id,
-        "card_id": ref.path(),
         "latest_revision": latest_revision,
         "options": meta.get("charm-config", {}).get("Options"),
         "owner": meta.get("owner", {}).get("User"),
@@ -206,10 +205,9 @@ def _parse_charm_data(charm_data, include_files=False):
         "series": meta.get("supported-series", {}).get("SupportedSeries"),
         # Some charms do not have tags, so fall back to categories if they
         # exist (mostly on older charms).
-        "tags": charm_metadata.get("Tags") or charm_metadata.get("Categories"),
-        "user": meta.get("owner", {}).get("User"),
-        "url": ref.jujucharms_id(),
         "is_charm": True,
+        "tags": charm_metadata.get("Tags") or charm_metadata.get("Categories"),
+        "url": ref.jujucharms_id(),
     }
 
     if include_files:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -96,19 +96,10 @@ def user_entity(username, entity_name):
 
     if entity:
         if entity["is_charm"]:
-            entity["description"] = entity["charm_data"]["Meta"][
-                "charm-metadata"
-            ]["Description"]
-            entity["user"] = entity["charm_data"]["Meta"]["owner"]["User"]
             return render_template(
                 "store/charm-details.html", context={"entity": entity}
             )
         else:
-            entity["user"] = entity["bundle_data"]["Meta"]["owner"]["User"]
-            entity["id"] = entity["bundle_data"]["Id"]
-            entity["meta_published_info"] = entity["bundle_data"]["Meta"][
-                "published"
-            ]["Info"]
             return render_template(
                 "store/bundle-details.html", context={"entity": entity}
             )
@@ -132,24 +123,10 @@ def details(charm_or_bundle_name, series_or_version=None, version=None):
 
     if entity:
         if entity["is_charm"]:
-            entity["meta_published_info"] = entity["charm_data"]["Meta"][
-                "published"
-            ]["Info"]
-            entity["description"] = entity["charm_data"]["Meta"][
-                "charm-metadata"
-            ]["Description"]
             return render_template(
                 "store/charm-details.html", context={"entity": entity}
             )
         else:
-            entity["user"] = entity["bundle_data"]["Meta"]["owner"]["User"]
-            entity["id"] = entity["bundle_data"]["Id"]
-            entity["series"] = entity["bundle_data"]["Meta"][
-                "bundle-metadata"
-            ].get("series")
-            entity["meta_published_info"] = entity["bundle_data"]["Meta"][
-                "published"
-            ]["Info"]
             return render_template(
                 "store/bundle-details.html", context={"entity": entity}
             )


### PR DESCRIPTION
## Done

- Normalise some model attributes to support the generic header.
- Add model tests.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- View some charms and bundles
- Check that the header details and description etc. appear as expected.

## Details

- Fixes: #90.
