### PR TITLE
Fix ProxyFix DeprecationWarning.

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,5 @@
 import flask
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.debug import DebuggedApplication
 
 import prometheus_flask_exporter


### PR DESCRIPTION
## Done

- Fix a DeprecationWarning for ProxyFix.

## QA

- Pull code
- Run `./run test`
- Check that there is no DeprecationWarning for ProxyFix in your console.
