### PR TITLE
Update relate command

### DIFF
--- a/static/js/cli-typer.js
+++ b/static/js/cli-typer.js
@@ -19,7 +19,7 @@ window.app.cliTyper = function(container, commentContainer) {
     'juju deploy jenkins',
     'juju deploy',
     'juju deploy jenkins-slave',
-    'juju add-relation jenkins jenkins-slave',
+    'juju relate jenkins jenkins-slave',
     'juju add-unit jenkins-slave -n 3',
     'juju add-user sarah',
     'juju grant sarah read prod-california',


### PR DESCRIPTION
## Done

- Update relate command on the homepage.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Check on the homepage that the command in the "Juju at your command" section displays "juju relate" not "juju add-relation" (you'll have to wait a while).

## Details

- Fixes: #98.
