### PR TITLE
Update the CDK name

### DIFF
--- a/templates/jaasai/containers.html
+++ b/templates/jaasai/containers.html
@@ -59,7 +59,7 @@
 <div class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="col-8">
-      <h3>The Canonical Distribution of Kubernetes</h3>
+      <h3>The Charmed Distribution of Kubernetes</h3>
       <p>This is kubernetes-core hooked into an Elastic cluster to aggregate all your container workload logs, and mine and visualize your container infrastructure log messaging. This bundle is geared towards full production usage.</p>
     </div>
   </div>

--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -64,7 +64,7 @@
       <h3 id="deploy-kubernetes-in-minutes">Deploy Kubernetes in minutes</h3>
       <img src="https://assets.ubuntu.com/v1/c45bb1aa-jaas5.gif" alt="Kuberneets overview GIF">
       <p>In partnership with Google, Canonical delivers a ‘pure K8s’ experience, tested across a wide range of clouds and integrated with modern metrics and monitoring.</p>
-      <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}">Canonical Distribution Of Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
+      <p>The <a href="{{ url_for('jaasstore.details', charm_or_bundle_name='canonical-kubernetes') }}">Charmed Distribution Of Kubernetes</a> is for full production usage. Start using Kubernetes today.</p>
       <div>
         <a href="{{ url_for('jaasai.kubernetes') }}" class="p-button--neutral">Learn more</a>
         <a href="{{ external_urls.gui }}?deploy-target=bundle/canonical-kubernetes-21" class="p-button--neutral">Launch Kubernetes</a>

--- a/templates/jaasai/kubernetes.html
+++ b/templates/jaasai/kubernetes.html
@@ -258,11 +258,11 @@
           <div class="row p-divider">
             <div class="col-4 p-divider__block">
               <h4><a href="https://medium.com/@samnco/how-we-commoditized-gpus-for-kubernetes-7131f3e9231f" class="p-link--external">The easy way to commoditise GPUs for Kubernetes</a></h4>
-              <p>Setting up your Deep Learning framework is now easier than ever with the new GPU integration of the Canonical Distribution of Kubernetes<a href="#kubernetes-notice"><sup>*</sup></a>. Perfect for production grade, on bare metal or in the cloud.</p>
+              <p>Setting up your Deep Learning framework is now easier than ever with the new GPU integration of the Charmed Distribution of Kubernetes<a href="#kubernetes-notice"><sup>*</sup></a>. Perfect for production grade, on bare metal or in the cloud.</p>
             </div>
             <div class="col-4 p-divider__block">
               <h4><a href="https://blog.ubuntu.com/2017/03/27/job-concurrency-in-kubernetes-lxd-cpu-pinning-to-the-rescue" class="p-link--external">Build a transcoding platform in minutes</a></h4>
-              <p>The Canonical Distribution of Kubernetes enables automatic discovery of GPU devices. Work as well with LXD to get a fine grain control mechanism to orchestrate video workflows and maximize the throughput of your clusters.</p>
+              <p>The Charmed Distribution of Kubernetes enables automatic discovery of GPU devices. Work as well with LXD to get a fine grain control mechanism to orchestrate video workflows and maximize the throughput of your clusters.</p>
             </div>
             <div class="col-4 p-divider__block">
               <h4><a href="https://github.com/deis/workflow" class="p-link--external">Transform your solution into a private PaaS</a></h4>

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -122,7 +122,9 @@ class TestStoreModels(unittest.TestCase):
             bundle["description"],
             "A highly-available, production-grade Kubernetes cluster.",
         )
-        self.assertEqual(bundle["display_name"], "canonical kubernetes")
+        self.assertEqual(
+            bundle["display_name"], "The Charmed Distribution of Kubernetes"
+        )
         self.assertEqual(bundle["id"], "cs:bundle/canonical-kubernetes-466")
         self.assertFalse(bundle["is_charm"])
         self.assertIsNone(bundle["latest_revision"])

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -267,7 +267,12 @@ def _get_display_name(name):
         :param name the charm/bundle name.
         :return a cleaned name for display.
     """
-    return name.replace("-", " ")
+    name = name.replace("-", " ")
+    # Hack to rename 'canonical kubernetes'. To be removed when display
+    # name has been implemented.
+    if name == 'canonical kubernetes':
+        name = 'the charmed distribution of kubernetes'
+    return name
 
 
 def _get_bug_url(name, bugs_url):

--- a/webapp/store/models.py
+++ b/webapp/store/models.py
@@ -270,8 +270,8 @@ def _get_display_name(name):
     name = name.replace("-", " ")
     # Hack to rename 'canonical kubernetes'. To be removed when display
     # name has been implemented.
-    if name == 'canonical kubernetes':
-        name = 'the charmed distribution of kubernetes'
+    if name == "canonical kubernetes":
+        name = "The Charmed Distribution of Kubernetes"
     return name
 
 


### PR DESCRIPTION
## Done

- Update references to CDK to be "The Charmed Distribution Of Kubernetes" instead of "Canonical Distribution".

## QA

- Pull code
- Run `./run clean && ./run serve`
- Visit /kubernetes /containers and /jaas
- They should have "Charmed Distribution" instead of "Canonical Distribution".
- Do a search for "Kubernetes".
- You should see "The Charmed Distribution Of Kubernetes" in the list.
- Click on it and check the bundle name is also "The Charmed Distribution Of Kubernetes".

## Details

- Fixes: #103 .
