### PR TITLE
Add/update browser titles

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
 
+{% block title %}404: page not found{% endblock %}
+
 {% block content %}
 <div class="p-strip--light">
   <div class="row">

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -3,7 +3,7 @@
 <head>
   <link rel="preconnect" href="https://www.google-analytics.com">
   <link rel="preconnect" href="https://assets.ubuntu.com">
-  <title>{% block title %}{% endblock %} | Juju</title>
+  <title>{% block title %}JAAS{% endblock %} | Juju</title>
   <meta charset="UTF-8" />
   <meta name="description" content="{% block description %}{% endblock %}" />
   <meta name="author" content="Canonical" />

--- a/templates/jaasai/index.html
+++ b/templates/jaasai/index.html
@@ -1,6 +1,6 @@
 {% extends "_layout.html" %}
 
-{% block title %}Jujucharms{% endblock %}
+{% block title %}JAAS - Juju as a Service{% endblock %}
 {% block description %}Juju is an open source, application and service modelling tool from Ubuntu that helps you deploy, manage and scale your applications on any cloud.{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Done

- Add a title to the 404 page.
- Update the homepage title from "Jujucharms".
- Add a default title.

## QA

- Pull code
- Run `./run clean && ./run serve`
- Visit /
- The browser title should not be "Jujucharms"
- Visit /404
- There should be a browser title.

## Details

- Fixes #87.
