### PR TITLE
Add 500 error page

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,18 @@
+{% extends "_layout.html" %}
+
+{% block title %}500: Server error{% endblock %}
+
+{% block content %}
+<div class="p-strip--light">
+  <div class="row">
+    <h1>500: Server error encountered - sorry for the inconvenience.</h1>
+    <nav>
+      <ul class="p-inline-list">
+        <li class="p-inline-list__item"><a href="{{ url_for('jaasai.index') }}" class="p-button--positive">Home</a></li>
+        <li class="p-inline-list__item"><a href="{{ url_for('jaasstore.store') }}" class="p-button--positive">Browse the store</a></li>
+        <li class="p-inline-list__item"><a href="{{ external_urls.issues }}" class="p-link--external">Submit a bug</a></li>
+      </ul>
+    </nav>
+  </div>
+</div>
+{% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -75,6 +75,15 @@ def init_handler(app):
 
         return flask.render_template("404.html", error=error.description), 404
 
+    @app.errorhandler(500)
+    def internal_server_error(error):
+        """
+        For 500 pages, display the 500.html template,
+        passing through the error.
+        """
+
+        return flask.render_template("500.html", error=error), 500
+
 
 def init_blueprint(app):
     app.register_blueprint(jaasai)


### PR DESCRIPTION
## Done

- Show a nice 500 page if there is a server error.

## QA

- Pull code
- In the .env file change `FLASK_DEBUG=true` to `FLASK_DEBUG=false`.
- In webapp/jaasai/views.py change the `index()` method to return `None`.
- Run `./run`
- Load /
- You should see the 500 page.

## Details

- Fixes: #127.
