### PR TITLE
Update the Spicule about section

### DIFF
--- a/templates/jaasai/experts/spicule.html
+++ b/templates/jaasai/experts/spicule.html
@@ -80,17 +80,18 @@
   <div class="row">
     <div class="col-4">
       <h3 class="expert__title">About us</h3>
-      <p>Spicule offers industry leading consultancy in the world of data-centric devops and systems automation.</p>
-      <p>Spicule have developed Anssr, a collection of BI solutions that provide an architecture for businesses to analyse, reveal patterns and gain insights into their company data.</p>
-      <p><a class="p-link--external" href="https://anssr.io/docs/deploying-anssr-bundle.html">Getting started with Anssr</a></p>
-      <p><a class="p-link--external" href="https://spicule.co.uk/anssr">Spicule home</a></p>
+      <p>Spicule is an industry-leading Big Data consultancy by providing agile Big Data platforms for enterprises of all sizes.</p>
+      <p>Spicule have developed Anssr, a collection of Big Data applications that provide an architecture for businesses to process, analyse, reveal patterns and gain insights into their company data.</p>
+      <p><a class="p-link--external" href="https://anssr.io/docs/deploying-an-anssr-bundle.html">Getting started with Anssr</a></p>
+      <p><a class="p-link--external" href="https://spicule.co.uk">Spicule home</a></p>
     </div>
     <div class="col-4">
       <h3 class="expert__title">Skills</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Data analytics</li>
+        <li class="p-list__item is-ticked">Streaming data platforms</li>
         <li class="p-list__item is-ticked">Enterprise search</li>
-        <li class="p-list__item is-ticked">Scalable system designs</li>
+        <li class="p-list__item is-ticked">Scalable systems designs</li>
         <li class="p-list__item is-ticked">Data service deployments</li>
         <li class="p-list__item is-ticked">Automation processes</li>
       </ul>


### PR DESCRIPTION
## Done

- Update the about and skills section of /experts/spicule

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/experts/spicule
- Check that the About Us and Skills sections (at the bottom of the page) match jujucharms.com/experts/spicule

## Details

- Fixes: #111.
