### PR TITLE
Update Spicule logo on the Spicule page

### DIFF
--- a/templates/jaasai/experts/spicule.html
+++ b/templates/jaasai/experts/spicule.html
@@ -17,7 +17,7 @@
           <img
             style="padding-top:1rem"
             width="160"
-            src="https://assets.ubuntu.com/v1/c47163e1-Logo-Spicule.png"
+            src="{{ url_for('static', filename='img/logos/spicule.png') }}"
             alt="Spicule logo" />
         </h2>
         <hr>


### PR DESCRIPTION
## Done

- Update to the new Spicule logo on /experts/spicule

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open /experts/spicule
- Check that the logo in the top right has a tag line (same as https://jujucharms.com/experts/spicule).

## Details

- Fixes: #142.
