### PR TITLE
Remove hardcoded tags

### DIFF
--- a/static/sass/custom/_search-panel.scss
+++ b/static/sass/custom/_search-panel.scss
@@ -91,11 +91,4 @@
       max-width: 4rem;
     }
   }
-
-  &__item-count {
-    color: $color-mid-dark;
-  }
-
-  &__featured-link {
-  }
 }

--- a/templates/shared/search-panel.html
+++ b/templates/shared/search-panel.html
@@ -70,43 +70,38 @@
         <div class="p-search-panel__footer">
           <ul class="p-inline-list">
             <li class="p-inline-list__item">
+              <strong>Categories:</strong>
+            </li>
+            <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=openstack">openstack
-                <span class="p-search-panel__item-count">(108)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=applications">applications
-                <span class="p-search-panel__item-count">(248)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=databases">databases
-                <span class="p-search-panel__item-count">(71)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=app-servers">app-servers
-                <span class="p-search-panel__item-count">(75)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=file-servers">file-servers
-                <span class="p-search-panel__item-count">(48)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=monitoring">monitoring
-                <span class="p-search-panel__item-count">(28)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=misc">misc
-                <span class="p-search-panel__item-count">(279)</span>
               </a>
             </li>
             <li class="p-inline-list__item">
               <a href="{{ url_for('jaasstore.search') }}?tags=ops">ops
-                <span class="p-search-panel__item-count">(22)</span>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
## Done

Remove hardcoded tags from search panel. 

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Open the search panel by clicking in the search box
- Observe that tags are no more

## Details

Fixes #148 
