### PR TITLE
Selected nav items should be highlighted

### DIFF
--- a/static/sass/custom/_header.scss
+++ b/static/sass/custom/_header.scss
@@ -68,7 +68,8 @@ $color--background: #333333;
         text-decoration: none;
 
         @media (min-width: $breakpoint-medium) {
-          &:hover {
+          &:hover,
+          &.active {
             color: $color-mid-dark;
           }
         }

--- a/templates/jaasai/jaas.html
+++ b/templates/jaasai/jaas.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
 
+{% set active_section = "about" %}
+
 {% block title %}JAAS{% endblock %}
 {% block description %}JAAS gives you Juju, as a service{% endblock %}
 

--- a/templates/shared/navigation.html
+++ b/templates/shared/navigation.html
@@ -1,10 +1,12 @@
 <div class="p-header__nav-item" role="menuitem">
-  <a href="{{ url_for('jaasstore.store') }}">
+  <a href="{{ url_for('jaasstore.store') }}"
+    class="{% if active_section == 'store' %}active{% endif %}">
     Store
   </a>
 </div>
 <div class="p-header__nav-item" role="menuitem">
-  <a href="{{ url_for('jaasai.jaas') }}">
+  <a href="{{ url_for('jaasai.jaas') }}"
+    class="{% if active_section == 'about' %}active{% endif %}">
     About
   </a>
 </div>

--- a/templates/store/bundle-details.html
+++ b/templates/store/bundle-details.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
 
+{% set active_section = "store" %}
+
 {% block title %}{{ context.entity.display_name }}{% endblock %}
 
 {% block content %}

--- a/templates/store/charm-details.html
+++ b/templates/store/charm-details.html
@@ -1,8 +1,9 @@
 {% extends "_layout.html" %}
 
+{% set active_section = "store" %}
+
 {% block title %}{{ context.entity.display_name }}{% endblock %}
 {% block meta_description %}Deploy {{ context.entity.display_name }} to bare metal and public or private clouds using the Juju GUI or command line.{% endblock %}
-
 
 {% block meta_tags %}
   <meta property="og:title" content="{{ context.entity.display_name }}" />

--- a/templates/store/search.html
+++ b/templates/store/search.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
 
+{% set active_section = "store" %}
+
 {% block title %}Search results for {{ context.query }}{% endblock %}
 
 {% block content %}

--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -1,5 +1,7 @@
 {% extends "_layout.html" %}
 
+{% set active_section = "store" %}
+
 {% block title %}Store{% endblock %}
 {% block description %}Browse Juju's entire repository of solutions and find Charms or Bundles for any problem, including OpenStack, Big Data, MongoDB and Elastic search.{% endblock %}
 


### PR DESCRIPTION
## Done

Selected nav items should be highlighted

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Click on 'Store' in the primary nav and observe that active styling is persistent
- Click on 'About' in the primary nav and observe that active styling is persistent

## Details

Fixes #153 
