### PR TITLE
Use ‘q’ instead of ‘name’ as search query identifier

### DIFF
--- a/templates/shared/_navigation-search.html
+++ b/templates/shared/_navigation-search.html
@@ -1,5 +1,5 @@
 <form data-js="search-form" action="/q" method="GET">
-  <input type="search" name="text" data-js="form-text" placeholder="Search the store" class="p-header__search-input" value="{% if results %}{{ text }}{% endif %}"
+  <input type="search" name="q" data-js="form-text" placeholder="Search the store" class="p-header__search-input" value="{% if results %}{{ text }}{% endif %}"
   />
   <button class="p-header__search-submit" type="submit">
     <img src="https://assets.ubuntu.com/v1/a2ab4b7d-search.svg" alt="Search icon">


### PR DESCRIPTION
## Done

Use ‘q’ instead of ‘name’ as search query identifier for reasons Robin [outlined in detail.](https://github.com/canonical-websites/jaas.ai/issues/159)

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- Search for something in the header search box
- Confirm that the URL is `http://0.0.0.0:8029/search?q={YOUR_SEARCH_TERM}`

## Details

Fixes #159
