### PR TITLE
Remove hard coded store tag counts

### DIFF
--- a/templates/store/store.html
+++ b/templates/store/store.html
@@ -58,21 +58,26 @@
 
 <div class="p-strip is-shallow is-bordered">
   <div class="row">
+    <div class="col-12">
+      <h3 class="p-muted-heading u-align--center" style="max-width:100%">Categories</h3>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-12 prefix-1 suffix-1 u-align--center">
       <ul class="p-inline-list">
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='databases') }}">databases</a> (19),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='app-servers') }}">app-servers</a> (19),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='file-servers') }}">file-servers</a> (16),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='monitoring') }}">monitoring</a> (14),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='ops') }}">ops</a> (9),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='openstack') }}">openstack</a> (51),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='applications') }}">applications</a> (75),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='misc') }}">misc</a> (63),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='network') }}">network</a> (11),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='analytics') }}">analytics</a> (7),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='apache') }}">apache</a> (38),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='security') }}">security</a> (4),</li>
-        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='storage') }}">storage</a> (17),</li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='databases') }}">databases</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='app-servers') }}">app-servers</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='file-servers') }}">file-servers</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='monitoring') }}">monitoring</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='ops') }}">ops</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='openstack') }}">openstack</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='applications') }}">applications</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='misc') }}">misc</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='network') }}">network</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='analytics') }}">analytics</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='apache') }}">apache</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='security') }}">security</a></li>
+        <li class="p-inline-list__item"><a class="p-link--strong" href="{{ url_for('jaasstore.search', text='storage') }}">storage</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

Remove hardcoded store tag counts

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029/store
- Observe the counts next to tags are no more