### PR TITLE
Update ‘Getting started’ link in primary nav

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -55,9 +55,7 @@ def create_app(testing=False):
                 "askubuntu": "https://askubuntu.com/questions/tagged/juju",
                 "charmstore": "https://api.jujucharms.com/charmstore/v5/",
                 "discourse": "https://discourse.jujucharms.com/",
-                "gettingStarted": (
-                    "https://docs.jujucharms.com/2.5/en/getting-started"
-                ),
+                "gettingStarted": "https://jujucharms.com/new/",
                 "docs": "https://docs.jujucharms.com/",
                 "gui": "https://jujucharms.com/new/",
                 "issues": (


### PR DESCRIPTION
## Done

Update ‘Getting started’ link in primary nav

## QA

- Pull code
- Run `./run clean && ./run serve`
- Open http://0.0.0.0:8029
- click 'Getting started' in Global nav
- You should be directed to https://jujucharms.com/new/

## Details

Fixes https://github.com/ubuntudesign/juju-squad/issues/557
